### PR TITLE
Add RoutingContext to manage redirection stack automatically.

### DIFF
--- a/src/Infrastructure/BotSharp.Abstraction/Conversations/Models/RoleDialogModel.cs
+++ b/src/Infrastructure/BotSharp.Abstraction/Conversations/Models/RoleDialogModel.cs
@@ -1,3 +1,5 @@
+using BotSharp.Abstraction.Routing.Models;
+
 namespace BotSharp.Abstraction.Conversations.Models;
 
 public class RoleDialogModel
@@ -27,11 +29,6 @@ public class RoleDialogModel
     /// It's ideal to render in rich content in UI.
     /// </summary>
     public object ExecutionData { get; set; }
-
-    /// <summary>
-    /// Intent name
-    /// </summary>
-    public string IntentName {  get; set; }
 
     /// <summary>
     /// Stop conversation completion

--- a/src/Infrastructure/BotSharp.Abstraction/Routing/Models/RoutingContext.cs
+++ b/src/Infrastructure/BotSharp.Abstraction/Routing/Models/RoutingContext.cs
@@ -1,0 +1,40 @@
+namespace BotSharp.Abstraction.Routing.Models;
+
+public class RoutingContext
+{
+    private Stack<string> _stack { get; set; }
+        = new Stack<string>();
+
+    /// <summary>
+    /// Intent name
+    /// </summary>
+    public string IntentName { get; set; }
+
+    public string OriginAgentId
+        => _stack.Last();
+
+    public string CurrentAgentId 
+        => _stack.Peek();
+
+    public void Push(string agentId)
+    {
+        if (_stack.Count == 0 || _stack.Peek() != agentId)
+        {
+            _stack.Push(agentId);
+        }
+    }
+
+    /// <summary>
+    /// Pop current agent
+    /// </summary>
+    /// <returns>Return next agent</returns>
+    public string Pop()
+    {
+        if (_stack.Count > 1)
+        {
+            _stack.Pop();
+        }
+
+        return _stack.Peek();
+    }
+}

--- a/src/Infrastructure/BotSharp.Core/BotSharpServiceCollectionExtensions.cs
+++ b/src/Infrastructure/BotSharp.Core/BotSharpServiceCollectionExtensions.cs
@@ -10,6 +10,7 @@ using BotSharp.Core.Instructs;
 using BotSharp.Abstraction.Instructs;
 using BotSharp.Abstraction.Routing;
 using BotSharp.Core.Routing.Hooks;
+using BotSharp.Abstraction.Routing.Models;
 
 namespace BotSharp.Core;
 
@@ -32,6 +33,7 @@ public static class BotSharpServiceCollectionExtensions
         services.AddScoped<IConversationStorage, ConversationStorage>();
         services.AddScoped<IConversationService, ConversationService>();
         services.AddScoped<IConversationStateService, ConversationStateService>();
+        services.AddScoped<RoutingContext>();
 
         var databaseSettings = new DatabaseBasicSettings();
         config.Bind("Database", databaseSettings);

--- a/src/Infrastructure/BotSharp.Core/Routing/Handlers/RouteToAgentRoutingHandler.cs
+++ b/src/Infrastructure/BotSharp.Core/Routing/Handlers/RouteToAgentRoutingHandler.cs
@@ -37,11 +37,13 @@ public class RouteToAgentRoutingHandler : RoutingHandlerBase, IRoutingHandler
             {
                 AgentName = inst.AgentName
             }),
+            CurrentAgentId = routing.Dialogs.Last().CurrentAgentId
         };
 
         var ret = await function.Execute(message);
 
-        var result = await routing.InvokeAgent(message.CurrentAgentId);
+        var context = _services.GetRequiredService<RoutingContext>();
+        var result = await routing.InvokeAgent(context.CurrentAgentId);
         
         return result;
     }

--- a/src/Infrastructure/BotSharp.Core/Routing/RouteToAgentFn.cs
+++ b/src/Infrastructure/BotSharp.Core/Routing/RouteToAgentFn.cs
@@ -13,15 +13,20 @@ public class RouteToAgentFn : IFunctionCallback
 {
     public string Name => "route_to_agent";
     private readonly IServiceProvider _services;
+    private readonly RoutingContext _context;
 
-    public RouteToAgentFn(IServiceProvider services)
+    public RouteToAgentFn(IServiceProvider services, RoutingContext context)
     {
         _services = services;
+        _context = context;
     }
 
     public async Task<bool> Execute(RoleDialogModel message)
     {
         var args = JsonSerializer.Deserialize<RoutingArgs>(message.FunctionArgs);
+
+        // Push to routing stack
+        _context.Push(message.CurrentAgentId);
 
         if (string.IsNullOrEmpty(args.AgentName))
         {
@@ -45,6 +50,8 @@ public class RouteToAgentFn : IFunctionCallback
                 }
             }
         }
+
+        _context.Push(message.CurrentAgentId);
 
         // Set default execution data
         message.ExecutionData = JsonSerializer.Deserialize<JsonElement>(message.FunctionArgs);

--- a/src/Infrastructure/BotSharp.Core/Routing/RoutingService.InvokeAgent.cs
+++ b/src/Infrastructure/BotSharp.Core/Routing/RoutingService.InvokeAgent.cs
@@ -5,7 +5,7 @@ namespace BotSharp.Core.Routing;
 
 public partial class RoutingService
 {
-    const int MAXIMUM_RECURSION_DEPTH = 2;
+    const int MAXIMUM_RECURSION_DEPTH = 3;
     int CurrentRecursionDepth = 0;
     public async Task<RoleDialogModel> InvokeAgent(string agentId)
     {

--- a/src/Infrastructure/BotSharp.Core/Templating/ResponseTemplateService.cs
+++ b/src/Infrastructure/BotSharp.Core/Templating/ResponseTemplateService.cs
@@ -1,4 +1,5 @@
 using BotSharp.Abstraction.Repositories;
+using BotSharp.Abstraction.Routing.Models;
 using BotSharp.Abstraction.Templating;
 using System.IO;
 using System.Reflection;
@@ -64,7 +65,8 @@ public class ResponseTemplateService : IResponseTemplateService
         //    .ToList();
 
         var db = _services.GetRequiredService<IBotSharpRepository>();
-        var responses = db.GetAgentResponses(agentId, "intent", message.IntentName);
+        var context = _services.GetRequiredService<RoutingContext>();
+        var responses = db.GetAgentResponses(agentId, "intent", context.IntentName);
 
         if (responses.Count == 0)
         {

--- a/src/Plugins/BotSharp.Plugin.RoutingSpeeder/RoutingConversationHook.cs
+++ b/src/Plugins/BotSharp.Plugin.RoutingSpeeder/RoutingConversationHook.cs
@@ -11,6 +11,7 @@ using BotSharp.Plugin.RoutingSpeeder.Providers;
 using BotSharp.Abstraction.Agents;
 using System.IO;
 using BotSharp.Abstraction.Routing.Settings;
+using BotSharp.Abstraction.Routing.Models;
 
 namespace BotSharp.Plugin.RoutingSpeeder;
 
@@ -30,14 +31,13 @@ public class RoutingConversationHook: ConversationHookBase
 
         // intentClassifier.Train();
         // Utilize local discriminative model to predict intent
-        var predText = intentClassifier.Predict(vector);
+        var context = _services.GetRequiredService<RoutingContext>();
+        context.IntentName = intentClassifier.Predict(vector);
 
-        if (string.IsNullOrEmpty(predText))
+        if (string.IsNullOrEmpty(context.IntentName))
         {
             return;
         }
-
-        message.IntentName = predText;
 
         // Render by template
         var templateService = _services.GetRequiredService<IResponseTemplateService>();


### PR DESCRIPTION
`RoutingContext` will manage the agent calling stack, in the future, we don't pass the `CurrentAgentId` along with message. the context will know the the current agent.