### PR TITLE
Update TranslationService.cs

### DIFF
--- a/src/Infrastructure/BotSharp.Core/Translation/TranslationService.cs
+++ b/src/Infrastructure/BotSharp.Core/Translation/TranslationService.cs
@@ -310,7 +310,8 @@ public class TranslationService : ITranslationService
     /// <returns></returns>
     private async Task<TranslationOutput> InnerTranslate(List<TranslationInput> texts, string language, string template)
     {
-        var jsonString = JsonSerializer.Serialize(texts);
+        var options = new JsonSerializerOptions() { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+        var jsonString = JsonSerializer.Serialize(texts, options);
         var translator = new Agent
         {
             Id = Guid.Empty.ToString(),


### PR DESCRIPTION
hotfix json html escaped question
error:
[ERR] [] '<' is not a hex digit following '\u' within a JSON string. The string should be correctly escaped. Path: $.texts[0].text | LineNumber: 0 | BytePositionInLine: 411.

json:
{"input_lang":"English", "output_count":3, "output_lang":"Spanish", "texts":[{"id":1,"text":"Aquí hay un resumen de los horarios que ha indicado que está disponible. Las fechas no están confirmadas. El técnico revisará y se pondrá en contacto para programar.\u003Cp\u003E\u003Cb\u003EJueves, 23 de mayo de 2024\u003C/b\u003E\u003C/br\u003ETodo el día (08:00 AM - 08:00 PM)\u003C/p\u003E\u003Cp\u003E\u003<b>Viernes, 24 de mayo de 2024\u003C/b\u003E\u003C/br\u003EMañana (08:00 AM - 01:00 PM)\u003C/p\u003E\u003Cp\u003E\u003<b>Lunes, 27 de mayo de 2024\u003C/b\u003E\u003C/br\u003ETarde (01:00 PM - 08:00 PM)\u003C/p\u003E"},{"id":2,"text":"Se ve bien"},{"id":3,"text":"Empezar de nuevo"}]}