### PR TITLE
Docs: Typo Fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ It's written in C# running on .Net Core that is full cross-platform framework, t
 
 * Built-in multi-agents and conversation with state management.
 * Support multiple LLM Planning approaches to handle different tasks from simple to complex.
-* Built-in RAG related interfaces, Memeory based vector searching.
+* Built-in RAG related interfaces, Memory based vector searching.
 * Support multiple AI platforms (ChatGPT 3.5 / 4.0, PaLM 2, LLaMA 3, Claude Sonnet 3.5, HuggingFace).
 * Allow multiple agents with different responsibilities cooperate to complete complex tasks. 
 * Build, test, evaluate and audit your LLM agent in one place.


### PR DESCRIPTION
Corrected "Memeory" to "Memory" in [README.md].

This pull request addresses a minor typo found in repository. The typo has been corrected to improve clarity and maintain the quality of the documentation.

This change is purely cosmetic and does not affect functionality.