### PR TITLE
add plugin provider vertexai

### DIFF
--- a/BotSharp.sln
+++ b/BotSharp.sln
@@ -117,7 +117,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BotSharp.Plugin.Graph", "sr
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BotSharp.Plugin.AudioHandler", "src\Plugins\BotSharp.Plugin.AudioHandler\BotSharp.Plugin.AudioHandler.csproj", "{F57F4862-F8D4-44A1-AC12-5C131B5C9785}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BotSharp.Core.SideCar", "src\Infrastructure\BotSharp.Core.SideCar\BotSharp.Core.SideCar.csproj", "{6D3A54F9-4792-41DB-BE7D-4F7B1D918EAE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BotSharp.Core.SideCar", "src\Infrastructure\BotSharp.Core.SideCar\BotSharp.Core.SideCar.csproj", "{6D3A54F9-4792-41DB-BE7D-4F7B1D918EAE}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BotSharp.Plugin.VertexAI", "src\Plugins\BotSharp.Plugin.LangChain\BotSharp.Plugin.VertexAI.csproj", "{7DA2DCD0-551B-432E-AA5C-22DDD3ED459B}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -479,6 +481,14 @@ Global
 		{6D3A54F9-4792-41DB-BE7D-4F7B1D918EAE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{6D3A54F9-4792-41DB-BE7D-4F7B1D918EAE}.Release|x64.ActiveCfg = Release|Any CPU
 		{6D3A54F9-4792-41DB-BE7D-4F7B1D918EAE}.Release|x64.Build.0 = Release|Any CPU
+		{7DA2DCD0-551B-432E-AA5C-22DDD3ED459B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7DA2DCD0-551B-432E-AA5C-22DDD3ED459B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7DA2DCD0-551B-432E-AA5C-22DDD3ED459B}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7DA2DCD0-551B-432E-AA5C-22DDD3ED459B}.Debug|x64.Build.0 = Debug|Any CPU
+		{7DA2DCD0-551B-432E-AA5C-22DDD3ED459B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7DA2DCD0-551B-432E-AA5C-22DDD3ED459B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7DA2DCD0-551B-432E-AA5C-22DDD3ED459B}.Release|x64.ActiveCfg = Release|Any CPU
+		{7DA2DCD0-551B-432E-AA5C-22DDD3ED459B}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -536,6 +546,7 @@ Global
 		{EBFE97DA-D0BA-48BA-8B5D-083B60348D1D} = {97A0B191-64D7-4F8A-BFE8-1BFCC5E247E1}
 		{F57F4862-F8D4-44A1-AC12-5C131B5C9785} = {51AFE054-AE99-497D-A593-69BAEFB5106F}
 		{6D3A54F9-4792-41DB-BE7D-4F7B1D918EAE} = {E29DC6C4-5E57-48C5-BCB0-6B8F84782749}
+		{7DA2DCD0-551B-432E-AA5C-22DDD3ED459B} = {D5293208-2BEF-42FC-A64C-5954F61720BA}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A9969D89-C98B-40A5-A12B-FC87E55B3A19}

--- a/src/Plugins/BotSharp.Plugin.LangChain/BotSharp.Plugin.VertexAI.csproj
+++ b/src/Plugins/BotSharp.Plugin.LangChain/BotSharp.Plugin.VertexAI.csproj
@@ -1,0 +1,21 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>$(TargetFramework)</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>$(LangVersion)</LangVersion>
+    <VersionPrefix>$(BotSharpVersion)</VersionPrefix>
+    <GeneratePackageOnBuild>$(GeneratePackageOnBuild)</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>$(GenerateDocumentationFile)</GenerateDocumentationFile>
+    <OutputPath>$(SolutionDir)packages</OutputPath>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="LangChain.Providers.Google.VertexAI" Version="0.15.3-dev.58" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\Infrastructure\BotSharp.Abstraction\BotSharp.Abstraction.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Plugins/BotSharp.Plugin.LangChain/Providers/ChatCompletionProvider.cs
+++ b/src/Plugins/BotSharp.Plugin.LangChain/Providers/ChatCompletionProvider.cs
@@ -1,0 +1,72 @@
+using BotSharp.Abstraction.Agents.Enums;
+using BotSharp.Abstraction.Agents.Models;
+using BotSharp.Abstraction.Conversations.Models;
+using BotSharp.Abstraction.Loggers;
+using BotSharp.Abstraction.MLTasks;
+using LangChain.Providers;
+using LangChain.Providers.Google.VertexAI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BotSharp.Plugin.VertexAI.Providers
+{
+    public class ChatCompletionProvider(
+    VertexAIConfiguration config,
+    ChatSettings settings,
+    ILogger<TextCompletionProvider> logger,
+    IServiceProvider services) : IChatCompletion
+    {
+        public string Provider => "vertexai";
+        private readonly VertexAIConfiguration _config = config;
+        private readonly ChatSettings? _settings = settings;
+        private readonly IServiceProvider _services = services;
+        private readonly ILogger _logger = logger;
+        public required string _model;
+
+        public void SetModelName(string model)
+        {
+            _model = model;
+        }
+
+        public async Task<RoleDialogModel> GetChatCompletions(Agent agent, List<RoleDialogModel> conversations)
+        {
+            var hooks = _services.GetServices<IContentGeneratingHook>().ToList();
+            Task.WaitAll(hooks.Select(hook =>
+            hook.BeforeGenerating(agent, conversations)).ToArray());
+            var client = new VertexAIProvider(_config);
+            var model = new VertexAIChatModel(client, _model);
+            var messages = conversations
+                .Select(c => new Message(c.Content, c.Role == AgentRole.User ? MessageRole.Human : MessageRole.Ai)).ToList();
+
+            var response = await model.GenerateAsync(new ChatRequest { Messages = messages }, _settings);
+
+           var msg = new RoleDialogModel(MessageRole.Ai.ToString(), response.LastMessageContent)
+            {
+                CurrentAgentId = agent.Id
+            };
+
+            Task.WaitAll(hooks.Select(hook =>
+            hook.AfterGenerated(msg, new TokenStatsModel
+            {
+                Prompt = response.Messages[0].Content,
+                Model = _model
+            })).ToArray());
+
+            return msg;
+        }
+
+        public Task<bool> GetChatCompletionsAsync(Agent agent, List<RoleDialogModel> conversations, Func<RoleDialogModel, Task> onMessageReceived, Func<RoleDialogModel, Task> onFunctionExecuting)
+        {
+            throw new NotImplementedException();
+        }
+
+        public Task<bool> GetChatCompletionsStreamingAsync(Agent agent, List<RoleDialogModel> conversations, Func<RoleDialogModel, Task> onMessageReceived)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/src/Plugins/BotSharp.Plugin.LangChain/Providers/ChatCompletionProvider.cs
+++ b/src/Plugins/BotSharp.Plugin.LangChain/Providers/ChatCompletionProvider.cs
@@ -14,11 +14,10 @@ using System.Threading.Tasks;
 
 namespace BotSharp.Plugin.VertexAI.Providers
 {
-    public class ChatCompletionProvider(
-    VertexAIConfiguration config,
-    ChatSettings settings,
-    ILogger<TextCompletionProvider> logger,
-    IServiceProvider services) : IChatCompletion
+    public class ChatCompletionProvider(VertexAIConfiguration config,
+        ChatSettings settings,
+        ILogger<TextCompletionProvider> logger,
+        IServiceProvider services) : IChatCompletion
     {
         public string Provider => "vertexai";
         private readonly VertexAIConfiguration _config = config;

--- a/src/Plugins/BotSharp.Plugin.LangChain/Providers/TextCompletionProvider.cs
+++ b/src/Plugins/BotSharp.Plugin.LangChain/Providers/TextCompletionProvider.cs
@@ -13,11 +13,10 @@ using System.Threading.Tasks;
 
 namespace BotSharp.Plugin.VertexAI.Providers
 {
-    public class TextCompletionProvider(
-    VertexAIConfiguration config,
-    ChatSettings settings,
-    ILogger<TextCompletionProvider> logger,
-    IServiceProvider services) : ITextCompletion
+    public class TextCompletionProvider(VertexAIConfiguration config,
+        ChatSettings settings,
+        ILogger<TextCompletionProvider> logger,
+        IServiceProvider services) : ITextCompletion
     {
         public string Provider => "vertexai";
         private readonly VertexAIConfiguration _config = config;

--- a/src/Plugins/BotSharp.Plugin.LangChain/Providers/TextCompletionProvider.cs
+++ b/src/Plugins/BotSharp.Plugin.LangChain/Providers/TextCompletionProvider.cs
@@ -1,0 +1,65 @@
+using BotSharp.Abstraction.Agents.Enums;
+using BotSharp.Abstraction.Agents.Models;
+using BotSharp.Abstraction.Conversations.Models;
+using BotSharp.Abstraction.Loggers;
+using BotSharp.Abstraction.MLTasks;
+using LangChain.Providers;
+using LangChain.Providers.Google.VertexAI;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace BotSharp.Plugin.VertexAI.Providers
+{
+    public class TextCompletionProvider(
+    VertexAIConfiguration config,
+    ChatSettings settings,
+    ILogger<TextCompletionProvider> logger,
+    IServiceProvider services) : ITextCompletion
+    {
+        public string Provider => "vertexai";
+        private readonly VertexAIConfiguration _config = config;
+        private readonly ChatSettings? _settings = settings;
+        private readonly IServiceProvider _services = services;
+        private readonly ILogger _logger = logger;
+        public required string _model;
+
+        public async Task<string> GetCompletion(string text, string agentId, string messageId)
+        {
+            var contentHooks = _services.GetServices<IContentGeneratingHook>().ToList();
+            var agent = new Agent()
+            {
+                Id = agentId,
+            };
+
+            var client = new VertexAIProvider(_config);
+            var model = new VertexAIChatModel(client, _model);
+            var response = await model.GenerateAsync(text, _settings);
+
+            var responseMessage = new RoleDialogModel(AgentRole.Assistant, response.LastMessageContent)
+            {
+                CurrentAgentId = agentId,
+                MessageId = messageId
+            };
+
+            Task.WaitAll(contentHooks.Select(hook =>
+            hook.AfterGenerated(responseMessage, new TokenStatsModel
+            {
+                Prompt = text,
+                Provider = Provider,
+                Model = _model,
+                PromptCount = response.Usage.TotalTokens,
+                CompletionCount = response.Usage.OutputTokens
+            })).ToArray());
+
+            return response.LastMessageContent;
+        }
+
+        public void SetModelName(string model)
+        {
+            _model = model;
+        }
+    }
+}

--- a/src/Plugins/BotSharp.Plugin.LangChain/VertexAiPlugin.cs
+++ b/src/Plugins/BotSharp.Plugin.LangChain/VertexAiPlugin.cs
@@ -5,26 +5,24 @@ using BotSharp.Plugin.VertexAI.Providers;
 using LangChain.Providers.Google.VertexAI;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using System;
 
-namespace BotSharp.Plugin.VertexAI
+namespace BotSharp.Plugin.VertexAI;
+
+public class VertexAiPlugin : IBotSharpPlugin
 {
-    public class VertexAiPlugin : IBotSharpPlugin
-    {
-        public string Id => "962ff441-2b40-4db4-b530-49efb1688a75";
-        public string Name => "VertexAI";
-        public string Description => "VertexAI Service including text generation, text to image and other AI services.";
-        public string IconUrl => "https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Vertex_AI_Logo.svg/480px-Vertex_AI_Logo.svg.png";
+    public string Id => "962ff441-2b40-4db4-b530-49efb1688a75";
+    public string Name => "VertexAI";
+    public string Description => "VertexAI Service including text generation, text to image and other AI services.";
+    public string IconUrl => "https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Vertex_AI_Logo.svg/480px-Vertex_AI_Logo.svg.png";
 
-        public void RegisterDI(IServiceCollection services, IConfiguration config)
+    public void RegisterDI(IServiceCollection services, IConfiguration config)
+    {
+        services.AddScoped(provider =>
         {
-            services.AddScoped(provider =>
-            {
-                var settingService = provider.GetRequiredService<ISettingService>();
-                return settingService.Bind<VertexAIConfiguration>("VertexAI");
-            });
-            services.AddScoped<IChatCompletion, ChatCompletionProvider>();
-            services.AddScoped<ITextCompletion, TextCompletionProvider>();
-        }
+            var settingService = provider.GetRequiredService<ISettingService>();
+            return settingService.Bind<VertexAIConfiguration>("VertexAI");
+        });
+        services.AddScoped<IChatCompletion, ChatCompletionProvider>();
+        services.AddScoped<ITextCompletion, TextCompletionProvider>();
     }
 }

--- a/src/Plugins/BotSharp.Plugin.LangChain/VertexAiPlugin.cs
+++ b/src/Plugins/BotSharp.Plugin.LangChain/VertexAiPlugin.cs
@@ -1,0 +1,30 @@
+using BotSharp.Abstraction.MLTasks;
+using BotSharp.Abstraction.Plugins;
+using BotSharp.Abstraction.Settings;
+using BotSharp.Plugin.VertexAI.Providers;
+using LangChain.Providers.Google.VertexAI;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace BotSharp.Plugin.VertexAI
+{
+    public class VertexAiPlugin : IBotSharpPlugin
+    {
+        public string Id => "962ff441-2b40-4db4-b530-49efb1688a75";
+        public string Name => "VertexAI";
+        public string Description => "VertexAI Service including text generation, text to image and other AI services.";
+        public string IconUrl => "https://upload.wikimedia.org/wikipedia/commons/thumb/0/05/Vertex_AI_Logo.svg/480px-Vertex_AI_Logo.svg.png";
+
+        public void RegisterDI(IServiceCollection services, IConfiguration config)
+        {
+            services.AddScoped(provider =>
+            {
+                var settingService = provider.GetRequiredService<ISettingService>();
+                return settingService.Bind<VertexAIConfiguration>("VertexAI");
+            });
+            services.AddScoped<IChatCompletion, ChatCompletionProvider>();
+            services.AddScoped<ITextCompletion, TextCompletionProvider>();
+        }
+    }
+}


### PR DESCRIPTION
I made an adapter to add the vertexai provider plugin from the implementation I made at https://github.com/tryAGI/LangChain.Providers/tree/main/src/Google.VertexAI/src. 

The code may need some correction, it is the first one I have done, if it is functional it could be abstracted to be able to use all the providers and implementation in langchain dotnet.