### PR TITLE
realtime model not suppot v1/chat/completions

### DIFF
--- a/src/Infrastructure/BotSharp.Abstraction/MLTasks/ILlmProviderService.cs
+++ b/src/Infrastructure/BotSharp.Abstraction/MLTasks/ILlmProviderService.cs
@@ -6,7 +6,7 @@ public interface ILlmProviderService
 {
     LlmModelSetting GetSetting(string provider, string model);
     List<string> GetProviders();
-    LlmModelSetting GetProviderModel(string provider, string id, bool? multiModal = null, bool? realTime = false, bool imageGenerate = false);
+    LlmModelSetting GetProviderModel(string provider, string id, bool? multiModal = null, bool realTime = false, bool imageGenerate = false);
     List<LlmModelSetting> GetProviderModels(string provider);
     List<LlmProviderSetting> GetLlmConfigs(LlmConfigOptions? options = null);
 }

--- a/src/Infrastructure/BotSharp.Core/Infrastructures/CompletionProvider.cs
+++ b/src/Infrastructure/BotSharp.Core/Infrastructures/CompletionProvider.cs
@@ -172,7 +172,7 @@ public class CompletionProvider
         string? model = null,
         string? modelId = null,
         bool? multiModal = null,
-        bool? realTime = null,
+        bool realTime = false,
         bool imageGenerate = false,
         AgentLlmConfig? agentConfig = null)
     {

--- a/src/Infrastructure/BotSharp.Core/Infrastructures/LlmProviderService.cs
+++ b/src/Infrastructure/BotSharp.Core/Infrastructures/LlmProviderService.cs
@@ -44,7 +44,7 @@ public class LlmProviderService : ILlmProviderService
             ?.Models ?? new List<LlmModelSetting>();
     }
 
-    public LlmModelSetting GetProviderModel(string provider, string id, bool? multiModal = null, bool? realTime = false, bool imageGenerate = false)
+    public LlmModelSetting GetProviderModel(string provider, string id, bool? multiModal = null, bool realTime = false, bool imageGenerate = false)
     {
         var models = GetProviderModels(provider)
             .Where(x => x.Id == id);
@@ -54,10 +54,7 @@ public class LlmProviderService : ILlmProviderService
             models = models.Where(x => x.MultiModal == multiModal);
         }
 
-        if (realTime.HasValue)
-        {
-            models = models.Where(x => x.RealTime == realTime);
-        }
+        models = models.Where(x => x.RealTime == realTime);
 
         models = models.Where(x => x.ImageGeneration == imageGenerate);
 


### PR DESCRIPTION
errorMsg:
System.ClientModel.ClientResultException: HTTP 404 (invalid_request_error: )\nParameter: model\n\nThis is not a chat model and thus not supported in the v1/chat/completions endpoint. Did you mean to use v1/completions?