### PR TITLE
add default func

### DIFF
--- a/src/Infrastructure/BotSharp.Abstraction/Realtime/IRealtimeHub.cs
+++ b/src/Infrastructure/BotSharp.Abstraction/Realtime/IRealtimeHub.cs
@@ -13,5 +13,5 @@ public interface IRealtimeHub
 
     IRealTimeCompletion Completer { get; }
 
-    Task ConnectToModel(Func<string, Task> responseToUser);
+    Task ConnectToModel(Func<string, Task>? responseToUser = null, Func<string, Task>? init = null);
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added optional `init` parameter to `ConnectToModel` method.

- Updated method calls to handle nullable `responseToUser` and `init`.

- Improved flexibility in handling model connection callbacks.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IRealtimeHub.cs</strong><dd><code>Add optional `init` parameter to interface method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Infrastructure/BotSharp.Abstraction/Realtime/IRealtimeHub.cs

<li>Added an optional <code>init</code> parameter to <code>ConnectToModel</code>.<br> <li> Updated method signature for enhanced flexibility.


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1008/files#diff-615913863f41feaf3ecfafecd35dbe938b5b6f705d3df6f5303427dbfb839820">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RealtimeHub.cs</strong><dd><code>Enhance `ConnectToModel` with optional initialization callback</code></dd></summary>
<hr>

src/Infrastructure/BotSharp.Core.Realtime/Services/RealtimeHub.cs

<li>Modified <code>ConnectToModel</code> to accept optional <code>init</code> parameter.<br> <li> Updated method logic to handle nullable <code>responseToUser</code> and <code>init</code>.<br> <li> Ensured fallback to <code>Task.CompletedTask</code> when callbacks are null.


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1008/files#diff-f56841254d8ee55e4adde6ce1a111aec31027e9e3f2aede4ccaf8fe13ad8b4f4">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>