### PR TITLE
fix init state

### DIFF
--- a/src/Infrastructure/BotSharp.OpenAPI/Controllers/ConversationController.cs
+++ b/src/Infrastructure/BotSharp.OpenAPI/Controllers/ConversationController.cs
@@ -367,8 +367,8 @@ public class ConversationController : ControllerBase
         var routing = _services.GetRequiredService<IRoutingService>();
         routing.Context.SetMessageId(conversationId, inputMsg.MessageId);
 
-        SetStates(conv, input);
         conv.SetConversationId(conversationId, input.States);
+        SetStates(conv, input);
 
         var response = new ChatResponseModel();
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed the order of method calls in `ConversationController`.

- Ensured `SetStates` is called after setting conversation ID.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ConversationController.cs</strong><dd><code>Corrected method call sequence in conversation initialization</code></dd></summary>
<hr>

src/Infrastructure/BotSharp.OpenAPI/Controllers/ConversationController.cs

<li>Adjusted the order of <code>SetStates</code> and <code>SetConversationId</code> calls.<br> <li> Ensured proper initialization sequence for conversation state.


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1011/files#diff-77b03e3e2931444b2a225ca6df2ce2ad355d66a5e15c0e113fb9c20f82557f40">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>