### PR TITLE
refine init mcp

### DIFF
--- a/src/Infrastructure/BotSharp.Core.MCP/BotSharpMCPExtensions.cs
+++ b/src/Infrastructure/BotSharp.Core.MCP/BotSharpMCPExtensions.cs
@@ -43,18 +43,22 @@ public static class BotSharpMcpExtensions
 
     private static async Task RegisterFunctionCall(IServiceCollection services, McpServerConfigModel server, McpClientManager clientManager)
     {
-        var client = await clientManager.GetMcpClientAsync(server.Id);
-        var tools = await client.ListToolsAsync();
-
-        foreach (var tool in tools)
+        try
         {
-            services.AddScoped(provider => tool);
+            var client = await clientManager.GetMcpClientAsync(server.Id);
+            var tools = await client.ListToolsAsync();
 
-            services.AddScoped<IFunctionCallback>(provider =>
+            foreach (var tool in tools)
             {
-                var funcTool = new McpToolAdapter(provider, server.Name, tool, clientManager);
-                return funcTool;
-            });
+                services.AddScoped(provider => tool);
+
+                services.AddScoped<IFunctionCallback>(provider =>
+                {
+                    var funcTool = new McpToolAdapter(provider, server.Name, tool, clientManager);
+                    return funcTool;
+                });
+            }
         }
+        catch { }
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added error handling for `RegisterFunctionCall` and `Execute` methods.

- Improved robustness in `McpToolAdapter` with try-catch blocks.

- Fixed potential null or empty dictionary issues in JSON parsing.

- Enhanced logging for tool execution errors in `McpToolAdapter`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BotSharpMCPExtensions.cs</strong><dd><code>Added error handling in `RegisterFunctionCall` method</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Infrastructure/BotSharp.Core.MCP/BotSharpMCPExtensions.cs

<li>Added try-catch block to <code>RegisterFunctionCall</code>.<br> <li> Prevented unhandled exceptions during tool registration.<br> <li> Improved service registration logic for tools and callbacks.


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1012/files#diff-9c4f4df660781b79e2af22eb5fda74779278017f9507671587148a6d635cf3b4">+13/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>McpToolAdapter.cs</strong><dd><code>Improved error handling and robustness in `McpToolAdapter`</code></dd></summary>
<hr>

src/Infrastructure/BotSharp.Core.MCP/Functions/McpToolAdapter.cs

<li>Wrapped <code>Execute</code> method logic in a try-catch block.<br> <li> Added error message handling for tool execution failures.<br> <li> Fixed potential issues with empty or null JSON arguments.<br> <li> Enhanced robustness in tool execution and result processing.


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1012/files#diff-79f76b9868ede166881f7ce17c14bff5f855733da10c0e20e4cd9b28f119d39a">+24/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>