### PR TITLE
Update webdriver upload files method

### DIFF
--- a/src/Plugins/BotSharp.Plugin.WebDriver/Drivers/PlaywrightDriver/PlaywrightWebDriver.DoAction.cs
+++ b/src/Plugins/BotSharp.Plugin.WebDriver/Drivers/PlaywrightDriver/PlaywrightWebDriver.DoAction.cs
@@ -24,7 +24,7 @@ public partial class PlaywrightWebDriver
         }
         else if (count > 1)
         {
-            if(!action.FirstIfMultipleFound)
+            if (!action.FirstIfMultipleFound)
             {
                 Serilog.Log.Error($"Multiple eElements were found: {result.Selector}");
                 return;
@@ -102,26 +102,33 @@ public partial class PlaywrightWebDriver
             });
             var guid = Guid.NewGuid().ToString();
             var directory = Path.Combine(Path.GetTempPath(), guid);
-            if (Directory.Exists(directory))
-            {
-                Directory.Delete(directory, true);
-            }
+            DeleteDirectory(directory);
             Directory.CreateDirectory(directory);
             var localPaths = new List<string>();
-            using var httpClient = new HttpClient();
+            var http = _services.GetRequiredService<IHttpClientFactory>();
+            using var httpClient = http.CreateClient();
             foreach (var fileUrl in files)
             {
-                var bytes = await httpClient.GetByteArrayAsync(fileUrl);
-                var fileName = new Uri(fileUrl).AbsolutePath;
-                var localPath = Path.Combine(directory, Path.GetFileName(fileName));
-                await File.WriteAllBytesAsync(localPath, bytes);
-                await Task.Delay(2000);
-                localPaths.Add(localPath);
+                try
+                {
+                    using var fileData = await httpClient.GetAsync(fileUrl);
+                    var fileName = new Uri(fileUrl).AbsolutePath;
+                    var localPath = Path.Combine(directory, Path.GetFileName(fileName));
+                    await using var fs = new FileStream(localPath, FileMode.Create, FileAccess.Write, FileShare.None);
+                    await fileData.Content.CopyToAsync(fs);
+                    localPaths.Add(localPath);
+                }
+                catch (Exception ex)
+                {
+                    Serilog.Log.Error($"FileUpload failed for {fileUrl}. Message: {ex.Message}");
+                }
             }
             await fileChooser.SetFilesAsync(localPaths);
+            await Task.Delay(1000 * action.WaitTime);
         }
         else if (action.Action == BroswerActionEnum.Typing)
         {
+            await locator.PressSequentiallyAsync(action.Content);
             await locator.PressSequentiallyAsync(action.Content);
             if (action.PressKey != null)
             {
@@ -155,8 +162,8 @@ public partial class PlaywrightWebDriver
                     // Perform drag-and-move
                     // Move mouse to the start position
                     var mouse = page.Mouse;
-                    await mouse.MoveAsync(startX, startY); 
-                    await mouse.DownAsync();             
+                    await mouse.MoveAsync(startX, startY);
+                    await mouse.DownAsync();
 
                     // Move mouse smoothly in increments
                     var tracks = GetVelocityTrack(offsetX);
@@ -183,6 +190,13 @@ public partial class PlaywrightWebDriver
         if (action.WaitTime > 0)
         {
             await Task.Delay(1000 * action.WaitTime);
+        }
+    }
+    private void DeleteDirectory(string directory)
+    {
+        if (Directory.Exists(directory))
+        {
+            Directory.Delete(directory, true);
         }
     }
     public static List<int> GetVelocityTrack(float distance)

--- a/src/Plugins/BotSharp.Plugin.WebDriver/Drivers/PlaywrightDriver/PlaywrightWebDriver.DoAction.cs
+++ b/src/Plugins/BotSharp.Plugin.WebDriver/Drivers/PlaywrightDriver/PlaywrightWebDriver.DoAction.cs
@@ -129,7 +129,6 @@ public partial class PlaywrightWebDriver
         else if (action.Action == BroswerActionEnum.Typing)
         {
             await locator.PressSequentiallyAsync(action.Content);
-            await locator.PressSequentiallyAsync(action.Content);
             if (action.PressKey != null)
             {
                 if (action.DelayBeforePressingKey > 0)


### PR DESCRIPTION
### **User description**
feat: stream downloads & use IHttpClientFactory

* Replace direct HttpClient creation with IHttpClientFactory
  – prevents socket exhaustion and long-lived handler leaks.

* Stream file content straight to FileStream (CopyToAsync)
  – no more full byte[] buffers in RAM

* Add per-file try/catch so one bad URL no longer aborts the batch.


___

### **PR Type**
Enhancement


___

### **Description**
• Replace HttpClient with IHttpClientFactory for better resource management
• Stream file downloads directly to disk instead of loading into memory
• Add error handling for individual file downloads
• Extract directory deletion logic into separate method


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PlaywrightWebDriver.DoAction.cs</strong><dd><code>Enhanced file upload with streaming and error handling</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Plugins/BotSharp.Plugin.WebDriver/Drivers/PlaywrightDriver/PlaywrightWebDriver.DoAction.cs

• Replace direct HttpClient instantiation with IHttpClientFactory<br> • <br>Stream file downloads using CopyToAsync instead of GetByteArrayAsync<br> • <br>Add try-catch blocks for individual file download error handling<br> • <br>Extract directory deletion logic into DeleteDirectory method<br> • Fix <br>minor formatting issues and duplicate typing action


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1077/files#diff-3647758165b4238c3e42470090a4091a8ed7cdb8ccdde1673bd6ba2086456893">+28/-14</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>