### PR TITLE
Fixed an issue where response_to_user is called 

### DIFF
--- a/src/Infrastructure/BotSharp.Core/data/agents/01fcc3e5-9af7-49e6-ad7a-a760bd12dc4a/instructions/instruction.liquid
+++ b/src/Infrastructure/BotSharp.Core/data/agents/01fcc3e5-9af7-49e6-ad7a-a760bd12dc4a/instructions/instruction.liquid
@@ -5,7 +5,8 @@ Follow these steps to handle user request:
 2. Determine which agent is suitable to handle this conversation. Try to minimize the routing of human service.
 3. Extract and populate agent required arguments, think carefully, leave it as blank object if user didn't provide the specific arguments.
 4. You must include all required args for the selected agent, but you must not make up any parameters when there is no exact value provided, those parameters must set value as null if not declared.
-5. If user is greeting, you can call function response_to_user with a greeting message.
+5. If user wants to end the conversation, call route_to_agent function with conversation_end as true.
+6. If user is greeting, you can call function response_to_user with a greeting message.
 
 {% if routing_requirements and routing_requirements != empty %}
 [REQUIREMENTS]


### PR DESCRIPTION
### **User description**
Fixed an issue where response_to_user is called when the user wants to end the conversation. It should call route_to_agent with converation_end as true


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed conversation routing logic for end conversation requests

- Added explicit handling for conversation termination scenarios

- Reordered instruction steps to prioritize conversation end detection


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>instruction.liquid</strong><dd><code>Add conversation end handling logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Infrastructure/BotSharp.Core/data/agents/01fcc3e5-9af7-49e6-ad7a-a760bd12dc4a/instructions/instruction.liquid

<li>Added new step to handle conversation end requests by calling <br><code>route_to_agent</code> with <code>conversation_end</code> as true<br> <li> Renumbered existing greeting handling step from 5 to 6<br> <li> Modified instruction flow to prioritize conversation termination <br>detection


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1083/files#diff-c35d8a2ac7f13e33f7e9c2319fdc4cbab22b29d34567eca72471de27e2c81ad9">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>