### PR TITLE
fix #1097 SqlDriver: Database type mssql is not supported

### DIFF
--- a/src/Plugins/BotSharp.Plugin.SqlDriver/Functions/ExecuteQueryFn.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/Functions/ExecuteQueryFn.cs
@@ -33,7 +33,7 @@ public class ExecuteQueryFn : IFunctionCallback
             var results = dbType.ToLower() switch
             {
                 "mysql" => RunQueryInMySql(args.SqlStatements),
-                "sqlserver" => RunQueryInSqlServer(args.SqlStatements),
+                "sqlserver" or "mssql" => RunQueryInSqlServer(args.SqlStatements),
                 "redshift" => RunQueryInRedshift(args.SqlStatements),
                 _ => throw new NotImplementedException($"Database type {dbType} is not supported.")
             };

--- a/src/Plugins/BotSharp.Plugin.SqlDriver/Functions/GetTableDefinitionFn.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/Functions/GetTableDefinitionFn.cs
@@ -37,7 +37,7 @@ public class GetTableDefinitionFn : IFunctionCallback
         var tableDdls = dbType switch
         {
             "mysql" => GetDdlFromMySql(tables),
-            "sqlserver" => GetDdlFromSqlServer(tables),
+            "sqlserver" or "mssql" => GetDdlFromSqlServer(tables),
             "redshift" => GetDdlFromRedshift(tables),
             _ => throw new NotImplementedException($"Database type {dbType} is not supported.")
         };

--- a/src/Plugins/BotSharp.Plugin.SqlDriver/Functions/SqlSelect.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/Functions/SqlSelect.cs
@@ -32,7 +32,7 @@ public class SqlSelect : IFunctionCallback
         var result = dbType switch
         {
             "mysql" => RunQueryInMySql(args),
-            "sqlserver" => RunQueryInSqlServer(args),
+            "sqlserver" or "mssql" => RunQueryInSqlServer(args),
             "redshift" => RunQueryInRedshift(args),
             _ => throw new NotImplementedException($"Database type {dbType} is not supported.")
         };

--- a/src/Plugins/BotSharp.Plugin.SqlDriver/Functions/SqlValidateFn.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/Functions/SqlValidateFn.cs
@@ -34,7 +34,7 @@ public class SqlValidateFn : IFunctionCallback
         var validateSql = dbType.ToLower() switch
         {
             "mysql" => $"EXPLAIN\r\n{sql.Replace("SET ", "-- SET ", StringComparison.InvariantCultureIgnoreCase).Replace(";", "; EXPLAIN ").TrimEnd("EXPLAIN ".ToCharArray())}",
-            "sqlserver" => $"SET PARSEONLY ON;\r\n{sql}\r\nSET PARSEONLY OFF;",
+            "sqlserver" or "mssql" => $"SET PARSEONLY ON;\r\n{sql}\r\nSET PARSEONLY OFF;",
             "redshift" => $"explain\r\n{sql}",
             _ => throw new NotImplementedException($"Database type {dbType} is not supported.")
         };

--- a/src/Plugins/BotSharp.Plugin.SqlDriver/UtilFunctions/GetTableDefinitionFn.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/UtilFunctions/GetTableDefinitionFn.cs
@@ -31,7 +31,7 @@ public class GetTableDefinitionFn : IFunctionCallback
         var tableDdls = dbType switch
         {
             "mysql" => GetDdlFromMySql(tables),
-            "sqlserver" => GetDdlFromSqlServer(tables),
+            "sqlserver" or "mssql" => GetDdlFromSqlServer(tables),
             "redshift" => GetDdlFromRedshift(tables,schema),
             _ => throw new NotImplementedException($"Database type {dbType} is not supported.")
         };

--- a/src/Plugins/BotSharp.Plugin.SqlDriver/UtilFunctions/SqlSelect.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/UtilFunctions/SqlSelect.cs
@@ -30,7 +30,7 @@ public class SqlSelect : IFunctionCallback
         var result = dbType switch
         {
             "mysql" => RunQueryInMySql(args),
-            "sqlserver" => RunQueryInSqlServer(args),
+            "sqlserver" or "mssql" => RunQueryInSqlServer(args),
             "redshift" => RunQueryInRedshift(args),
             _ => throw new NotImplementedException($"Database type {dbType} is not supported.")
         };


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Add support for 'mssql' database type identifier

- Update switch statements to handle both 'sqlserver' and 'mssql'

- Fix database type compatibility across SQL driver functions


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Database Type Detection"] --> B["Switch Statement"]
  B --> C["'sqlserver' or 'mssql'"]
  C --> D["SQL Server Operations"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ExecuteQueryFn.cs</strong><dd><code>Add mssql support to query execution</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Plugins/BotSharp.Plugin.SqlDriver/Functions/ExecuteQueryFn.cs

<li>Updated switch case to accept both 'sqlserver' and 'mssql' identifiers<br> <li> Routes both database types to RunQueryInSqlServer method


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1098/files#diff-e3d9c7e9211804ff104ea714a3ae1bd2c0646d734bcc88111544dc1862f8c84c">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GetTableDefinitionFn.cs</strong><dd><code>Support mssql in table definition retrieval</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Plugins/BotSharp.Plugin.SqlDriver/Functions/GetTableDefinitionFn.cs

<li>Modified switch statement to handle 'mssql' alongside 'sqlserver'<br> <li> Both types now use GetDdlFromSqlServer method


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1098/files#diff-ecb2be20019c04e44eea77281502e75946b32157599d2c1c96de3d6bdda725ea">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SqlSelect.cs</strong><dd><code>Enable mssql support in SQL select</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Plugins/BotSharp.Plugin.SqlDriver/Functions/SqlSelect.cs

<li>Added 'mssql' as alternative to 'sqlserver' in switch case<br> <li> Routes to RunQueryInSqlServer for both database types


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1098/files#diff-d0c13a48e145b79ad258020ddad2c644993069fde17cc8f428e06c78b6243f22">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SqlValidateFn.cs</strong><dd><code>Add mssql validation support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Plugins/BotSharp.Plugin.SqlDriver/Functions/SqlValidateFn.cs

<li>Updated validation logic to accept 'mssql' database type<br> <li> Uses same SQL Server validation syntax for both types


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1098/files#diff-e58c8659a65c8c718bdf14edae5243f53ba3065cc5d6ba65e08801065c74ba28">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GetTableDefinitionFn.cs</strong><dd><code>Support mssql in utility table definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Plugins/BotSharp.Plugin.SqlDriver/UtilFunctions/GetTableDefinitionFn.cs

<li>Modified switch to handle 'mssql' alongside 'sqlserver'<br> <li> Both types use GetDdlFromSqlServer utility method


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1098/files#diff-17ac0d37f7de2d8ee256941e038fe6504519c78251da5c296ac2b6a1524f9ddf">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>SqlSelect.cs</strong><dd><code>Enable mssql in utility SQL select</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Plugins/BotSharp.Plugin.SqlDriver/UtilFunctions/SqlSelect.cs

<li>Added 'mssql' as valid database type in switch statement<br> <li> Routes to RunQueryInSqlServer for both database identifiers


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1098/files#diff-bc55b4c44c80c5071384317958222aa08bf20064e2fa3bbb4aebb8c4aa0d9898">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>