### PR TITLE
feat(playwright): handle <select> dropdowns in DropDown action

### DIFF
--- a/src/Infrastructure/BotSharp.Core/Conversations/Services/ConversationStateService.cs
+++ b/src/Infrastructure/BotSharp.Core/Conversations/Services/ConversationStateService.cs
@@ -443,7 +443,7 @@ public class ConversationStateService : IConversationStateService
 
     public void SetCurrentState(ConversationState state)
     {
-        var values = _curStates.Values.ToList();
+        var values = state.Values.ToList();
         var copy = JsonSerializer.Deserialize<List<StateKeyValue>>(JsonSerializer.Serialize(values));
         _curStates = new ConversationState(copy ?? []);
     }


### PR DESCRIPTION
- Added support for native <select> dropdowns in `DoAction` when action type is DropDown
- Extracted <select> handling logic into a private method `HandleSelectDropDownAsync`
- Automatically compares current selected value before selecting new option
- Waits for `NetworkIdle` after postback-triggered change
- Logs both skip and change cases
- Fallbacks to div-based dropdown selection when element is not a <select>

<img width="1778" height="608" alt="Snipaste_2025-07-27_14-08-03" src="https://github.com/user-attachments/assets/3645790b-c5ff-45c3-9884-e23c2679ce7c" />
