### PR TITLE
Fix Twilio dispose issue.

### DIFF
--- a/src/Infrastructure/BotSharp.Core/Infrastructures/Websocket/AsyncWebsocketDataResultEnumerator.cs
+++ b/src/Infrastructure/BotSharp.Core/Infrastructures/Websocket/AsyncWebsocketDataResultEnumerator.cs
@@ -31,7 +31,6 @@ internal class AsyncWebsocketDataResultEnumerator : IAsyncEnumerator<ClientResul
     public ValueTask DisposeAsync()
     {
         ArrayPool<byte>.Shared.Return(_buffer, clearArray: true);
-        _webSocket?.Dispose();
         return new ValueTask(Task.CompletedTask);
     }
 

--- a/src/Infrastructure/BotSharp.Core/Session/LlmRealtimeSession.cs
+++ b/src/Infrastructure/BotSharp.Core/Session/LlmRealtimeSession.cs
@@ -26,7 +26,6 @@ public class LlmRealtimeSession : IDisposable
     public async Task ConnectAsync(Uri uri, Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default)
     {
         _disposed = false;
-        _webSocket?.Dispose();
         _webSocket = new ClientWebSocket();
 
         if (!headers.IsNullOrEmpty())

--- a/src/Plugins/BotSharp.Plugin.OpenAI/Providers/Realtime/RealTimeCompletionProvider.cs
+++ b/src/Plugins/BotSharp.Plugin.OpenAI/Providers/Realtime/RealTimeCompletionProvider.cs
@@ -69,7 +69,6 @@ public class RealTimeCompletionProvider : IRealTimeCompletion
         _model = realtimeSettings.Model;
         var settings = settingsService.GetSetting(Provider, _model);
 
-        _session?.Dispose();
         _session = new LlmRealtimeSession(_services, new ChatSessionOptions
         {
             Provider = Provider,


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Remove manual WebSocket dispose calls causing disposal issues

- Replace field-based session with using statement for proper disposal

- Fix resource management in Twilio streaming middleware


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Manual Dispose Calls"] --> B["Resource Management Issues"]
  B --> C["Remove Manual Dispose"]
  C --> D["Using Statement Pattern"]
  D --> E["Proper Resource Cleanup"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AsyncWebsocketDataResultEnumerator.cs</strong><dd><code>Remove manual WebSocket disposal</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Infrastructure/BotSharp.Core/Infrastructures/Websocket/AsyncWebsocketDataResultEnumerator.cs

- Remove manual WebSocket dispose call from DisposeAsync method


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1171/files#diff-ee625caa5d46678e8b4777061985d9b988528d5444802e6940c2fc5ffe22e48d">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LlmRealtimeSession.cs</strong><dd><code>Remove WebSocket disposal in ConnectAsync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Infrastructure/BotSharp.Core/Session/LlmRealtimeSession.cs

- Remove manual WebSocket dispose call before creating new instance


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1171/files#diff-f970028119e0bbbc1eb526d88676d5b5bfc076dde8be8b48e1ef83f9efea8013">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>RealTimeCompletionProvider.cs</strong><dd><code>Remove session disposal in Connect</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Plugins/BotSharp.Plugin.OpenAI/Providers/Realtime/RealTimeCompletionProvider.cs

- Remove manual session dispose call before creating new session


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1171/files#diff-b344d603e3df1dc9bac0e6d402fa9dff30be2ff1eca247667b614c9a96634eb5">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TwilioStreamMiddleware.cs</strong><dd><code>Fix session disposal with using pattern</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Plugins/BotSharp.Plugin.Twilio/TwilioStreamMiddleware.cs

<ul><li>Remove private session field and manual dispose calls<br> <li> Replace with using statement for proper resource management<br> <li> Update session usage throughout HandleWebSocket method</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1171/files#diff-0944f59f4b234dd97f947b3bfce37b926008aaed14dee6c87be6cca6ba696947">+3/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

