### PR TITLE
optimize RoleContent

### DIFF
--- a/src/Infrastructure/BotSharp.Abstraction/Conversations/Models/RoleDialogModel.cs
+++ b/src/Infrastructure/BotSharp.Abstraction/Conversations/Models/RoleDialogModel.cs
@@ -152,7 +152,7 @@ public class RoleDialogModel : ITrackableMessage
             }
             else
             {
-                text = !string.IsNullOrWhiteSpace(RichContent?.Message?.Text) ? RichContent.Message.Text : Content;
+                text = !string.IsNullOrWhiteSpace(Content) ? Content : RichContent?.Message?.Text;
             }
 
             return text;


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Reversed priority in `RoleContent` getter for non-user roles

- Now returns `Content` first, then falls back to `RichContent.Message.Text`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RoleContent getter"] --> B{"Role == User?"}
  B -- "Yes" --> C["Return Payload or Content"]
  B -- "No" --> D["Return Content or RichContent.Message.Text"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RoleDialogModel.cs</strong><dd><code>Reverse content priority in RoleContent getter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Infrastructure/BotSharp.Abstraction/Conversations/Models/RoleDialogModel.cs

<ul><li>Changed priority order in <code>RoleContent</code> getter for non-user roles<br> <li> Now checks <code>Content</code> before <code>RichContent.Message.Text</code> instead of vice <br>versa</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1183/files#diff-0bf303abb94ad554aa4065dbaba914ad2d78ecb2a902c673aa8f167e8711f139">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

