### PR TITLE
Delay one second inside LockAsync in crontab watcher

### DIFF
--- a/src/Infrastructure/BotSharp.Core.Crontab/Services/CrontabWatcher.cs
+++ b/src/Infrastructure/BotSharp.Core.Crontab/Services/CrontabWatcher.cs
@@ -31,14 +31,11 @@ public class CrontabWatcher : BackgroundService
 
             while (!stoppingToken.IsCancellationRequested)
             {
-                var delay = Task.Delay(1000, stoppingToken);
-
                 await locker.LockAsync(DIST_KEY, async () =>
                 {
                     await RunCronChecker(scope.ServiceProvider);
+                    await Task.Delay(1000, stoppingToken);
                 });
-
-                await delay;
             }
 
             _logger.LogWarning("Crontab Watcher background service is stopped.");


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Moved delay inside distributed lock to prevent race conditions

- Changed delay timing from before lock to after cron checker execution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Acquire Lock"] --> B["Run Cron Checker"]
  B --> C["Delay 1 Second"]
  C --> D["Release Lock"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CrontabWatcher.cs</strong><dd><code>Relocate delay inside distributed lock callback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Infrastructure/BotSharp.Core.Crontab/Services/CrontabWatcher.cs

<ul><li>Moved <code>Task.Delay(1000)</code> from outside to inside the <code>LockAsync</code> callback<br> <li> Delay now occurs after <code>RunCronChecker</code> execution instead of before lock <br>acquisition<br> <li> Ensures delay happens within the distributed lock scope</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1187/files#diff-413a56cb0d5ce412387065695417eb3528363e4c59067932054a9eefb7547353">+1/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

