### PR TITLE
Reapply "Handling redis timeout in RedisSubscriber"

### DIFF
--- a/src/Infrastructure/BotSharp.Core/Infrastructures/Events/RedisSubscriber.cs
+++ b/src/Infrastructure/BotSharp.Core/Infrastructures/Events/RedisSubscriber.cs
@@ -81,6 +81,10 @@ public class RedisSubscriber : IEventSubscriber
                     await HandleGroupMessage(db, channel, group, consumer, received, $"{channel}-Error");
                 }
             }
+            catch (RedisTimeoutException)
+            {
+                _logger.LogWarning($"Redis timeout for channel {channel}, will retry in next cycle");
+            }
             catch (Exception ex)
             {
                 _logger.LogError($"Error processing message: {ex.Message}\r\n{ex}");


### PR DESCRIPTION
### **User description**
This reverts commit b8636a7c40cb2f92e1f63a8de0a2cd0095236537.


___

### **PR Type**
Bug fix


___

### **Description**
- Added `RedisTimeoutException` handling in `RedisSubscriber` to prevent crashes

- Logs warning message and continues to next cycle on timeout

- Improves resilience of Redis subscription mechanism


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RedisSubscriber"] --> B["Catch RedisTimeoutException"]
  B --> C["Log Warning"]
  C --> D["Continue Next Cycle"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RedisSubscriber.cs</strong><dd><code>Handle Redis timeout exceptions gracefully</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Infrastructure/BotSharp.Core/Infrastructures/Events/RedisSubscriber.cs

<ul><li>Added <code>RedisTimeoutException</code> catch block before generic exception <br>handler<br> <li> Logs warning message with channel information on timeout<br> <li> Allows subscription loop to continue without delay on timeout</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1190/files#diff-f12cd19420986761e31e82f3560098a7cccda896042c1e304a2fbbb9cb565bd7">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

