### PR TITLE
optimize DistributedLocker

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -32,7 +32,7 @@
     <PackageVersion Include="Serilog.Sinks.File" Version="6.0.0" />
     <PackageVersion Include="Rougamo.Fody" Version="5.0.0" />
     <PackageVersion Include="Aspects.Cache" Version="2.0.4" />
-    <PackageVersion Include="DistributedLock.Redis" Version="1.0.3" />
+    <PackageVersion Include="DistributedLock.Redis" Version="1.1.0" />
     <PackageVersion Include="EntityFrameworkCore.BootKit" Version="8.9.0" />
     <PackageVersion Include="Fluid.Core" Version="2.11.1" />
     <PackageVersion Include="Nanoid" Version="3.1.0" />
@@ -84,7 +84,7 @@
     <PackageVersion Include="MySqlConnector" Version="2.4.0" />
     <PackageVersion Include="Npgsql" Version="8.0.7" />
     <PackageVersion Include="Tencent.QCloud.Cos.Sdk" Version="5.4.39" />
-    <PackageVersion Include="StackExchange.Redis" Version="2.7.27" />
+    <PackageVersion Include="StackExchange.Redis" Version="2.7.33" />
     <PackageVersion Include="StrongGrid" Version="0.108.0" />
     <PackageVersion Include="Twilio.AspNet.Common" Version="8.1.1" />
     <PackageVersion Include="Twilio.AspNet.Core" Version="8.1.1" />

--- a/src/Infrastructure/BotSharp.Core.Crontab/Services/CrontabWatcher.cs
+++ b/src/Infrastructure/BotSharp.Core.Crontab/Services/CrontabWatcher.cs
@@ -31,11 +31,15 @@ public class CrontabWatcher : BackgroundService
 
             while (!stoppingToken.IsCancellationRequested)
             {
-                await locker.LockAsync(DIST_KEY, async () =>
+                var isLocked = await locker.LockAsync(DIST_KEY, async () =>
                 {
                     await RunCronChecker(scope.ServiceProvider);
                     await Task.Delay(1000, stoppingToken);
                 });
+                if (isLocked == false)
+                { 
+                    await Task.Delay(1000, stoppingToken);
+                }
             }
 
             _logger.LogWarning("Crontab Watcher background service is stopped.");


### PR DESCRIPTION
### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Upgrade DistributedLock.Redis to v1.1.0 for improved locking

- Upgrade StackExchange.Redis to v2.7.33 for stability

- Handle failed lock acquisition with retry delay

- Capture lock result and add fallback delay logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CrontabWatcher Loop"] -->|"LockAsync with result"| B["Lock Acquired?"]
  B -->|"Yes"| C["Run Cron Checker"]
  B -->|"No"| D["Delay 1000ms"]
  C --> E["Delay 1000ms"]
  E --> A
  D --> A
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CrontabWatcher.cs</strong><dd><code>Add lock failure handling with retry delay</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Infrastructure/BotSharp.Core.Crontab/Services/CrontabWatcher.cs

<ul><li>Capture return value from <code>locker.LockAsync()</code> call<br> <li> Add conditional check for failed lock acquisition<br> <li> Implement retry delay when lock fails<br> <li> Prevent busy-waiting on lock contention</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1193/files#diff-413a56cb0d5ce412387065695417eb3528363e4c59067932054a9eefb7547353">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Directory.Packages.props</strong><dd><code>Update Redis and DistributedLock dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Directory.Packages.props

<ul><li>Upgrade DistributedLock.Redis from v1.0.3 to v1.1.0<br> <li> Upgrade StackExchange.Redis from v2.7.27 to v2.7.33<br> <li> Improve distributed locking and Redis client stability</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1193/files#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

