### PR TITLE
Revert "refine timeout"

### DIFF
--- a/src/Plugins/BotSharp.Plugin.PythonInterpreter/Functions/PyProgrammerFn.cs
+++ b/src/Plugins/BotSharp.Plugin.PythonInterpreter/Functions/PyProgrammerFn.cs
@@ -1,5 +1,6 @@
 using BotSharp.Abstraction.Coding.Settings;
 using Microsoft.Extensions.Logging;
+using Python.Runtime;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
@@ -118,33 +119,20 @@ public class PyProgrammerFn : IFunctionCallback
             return (false, "Unable to execute python code script.");
         }
 
-        CancellationTokenSource? cts = null;
         var (useLock, useProcess, timeoutSeconds) = GetCodeExecutionConfig();
-
-        try
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds));
+        var response = await processor.RunAsync(codeScript, options: new()
         {
-            if (timeoutSeconds != null)
-            {
-                cts = new CancellationTokenSource(TimeSpan.FromSeconds(timeoutSeconds.Value));
-            }
+            UseLock = useLock,
+            UseProcess = useProcess
+        }, cancellationToken: cts.Token);
 
-            var response = await processor.RunAsync(codeScript, options: new()
-            {
-                UseLock = useLock,
-                UseProcess = useProcess
-            }, cancellationToken: cts?.Token ?? CancellationToken.None);
-
-            if (response == null || !response.Success)
-            {
-                return (false, !string.IsNullOrEmpty(response?.ErrorMsg) ? response.ErrorMsg : "Failed to execute python code script.");
-            }
-
-            return (true, response.Result);
-        }
-        finally
+        if (response == null || !response.Success)
         {
-            cts?.Dispose();
+            return (false, !string.IsNullOrEmpty(response?.ErrorMsg) ? response.ErrorMsg : "Failed to execute python code script.");
         }
+
+        return (true, response.Result);
     }
 
     private async Task<string> GetChatCompletion(Agent agent, List<RoleDialogModel> dialogs)
@@ -213,15 +201,15 @@ public class PyProgrammerFn : IFunctionCallback
         };
     }
 
-    private (bool, bool, int?) GetCodeExecutionConfig()
+    private (bool, bool, int) GetCodeExecutionConfig()
     {
-        var codeExecution = _codingSettings.CodeExecution;
-        var defaultTimeoutSeconds = 3;
+        var useLock = false;
+        var useProcess = false;
+        var timeoutSeconds = 3;
 
-        var useLock = codeExecution?.UseLock ?? false;
-        var useProcess = codeExecution?.UseProcess ?? false;
-        var timeoutSeconds = codeExecution?.TimeoutSeconds != null
-            ? (codeExecution.TimeoutSeconds > 0 ? codeExecution.TimeoutSeconds : defaultTimeoutSeconds) : null;
+        useLock = _codingSettings.CodeExecution?.UseLock ?? useLock;
+        useProcess = _codingSettings.CodeExecution?.UseProcess ?? useProcess;
+        timeoutSeconds = _codingSettings.CodeExecution?.TimeoutSeconds > 0 ? _codingSettings.CodeExecution.TimeoutSeconds.Value : timeoutSeconds;
 
         return (useLock, useProcess, timeoutSeconds);
     }


### PR DESCRIPTION
### **User description**
Reverts SciSharp/BotSharp#1214


___

### **PR Type**
Bug fix


___

### **Description**
- Reverts timeout handling refinement to use non-nullable timeout values

- Removes try-finally blocks and uses `using` statement for CancellationTokenSource

- Simplifies timeout configuration logic with guaranteed default value

- Changes timeout return type from `int?` to `int` in GetCodeExecutionConfig


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Nullable timeout handling"] -->|Revert| B["Non-nullable timeout"]
  C["Try-finally pattern"] -->|Simplify| D["Using statement"]
  E["Conditional timeout creation"] -->|Simplify| F["Always create CancellationTokenSource"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>InstructService.Execute.cs</strong><dd><code>Simplify timeout handling with non-nullable values</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Infrastructure/BotSharp.Core/Instructs/Services/InstructService.Execute.cs

<ul><li>Removes try-finally block and replaces with <code>using</code> statement for <br>CancellationTokenSource<br> <li> Changes timeout parameter from nullable <code>int?</code> to non-nullable <code>int</code><br> <li> Simplifies timeout configuration to always use a default value of 3 <br>seconds<br> <li> Removes conditional null-coalescing logic for cancellation token</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1215/files#diff-37f4749182e4e35ee64fd99a8072d98e5d1f05c4e3f4a607c6e16722a6da1922">+44/-56</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PyProgrammerFn.cs</strong><dd><code>Simplify timeout handling and add missing import</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Plugins/BotSharp.Plugin.PythonInterpreter/Functions/PyProgrammerFn.cs

<ul><li>Adds missing <code>using Python.Runtime;</code> import statement<br> <li> Removes try-finally block and replaces with <code>using</code> statement for <br>CancellationTokenSource<br> <li> Changes timeout return type from nullable <code>int?</code> to non-nullable <code>int</code><br> <li> Simplifies timeout configuration logic with guaranteed default value</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1215/files#diff-9d451411b8090a5401e18031f2274ab4a1e34deb75ce065c1254256c8ea4dc52">+17/-29</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

