### PR TITLE
hotfix HttpContext NullReferenceException

### DIFF
--- a/src/Plugins/BotSharp.Plugin.ChatHub/SignalRHub.cs
+++ b/src/Plugins/BotSharp.Plugin.ChatHub/SignalRHub.cs
@@ -28,7 +28,8 @@ public class SignalRHub : Hub
         _logger.LogInformation($"SignalR Hub: {_user.FirstName} {_user.LastName} ({Context.User.Identity.Name}) connected in {Context.ConnectionId}");
 
         var convService = _services.GetRequiredService<IConversationService>();
-        _context.HttpContext.Request.Query.TryGetValue("conversation-id", out var conversationId);
+        var httpContext = Context.GetHttpContext();
+        string? conversationId = httpContext?.Request?.Query["conversation-id"].FirstOrDefault();
 
         if (!string.IsNullOrEmpty(conversationId))
         {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix NullReferenceException when HttpContext is unavailable

- Replace direct HttpContext access with safe null-coalescing pattern

- Use Context.GetHttpContext() for proper SignalR context retrieval


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Direct _context.HttpContext access"] -->|"causes NullReferenceException"| B["Unsafe code path"]
  C["Context.GetHttpContext() with null-coalescing"] -->|"safely handles null"| D["Robust code path"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SignalRHub.cs</strong><dd><code>Safe HttpContext access with null-coalescing operators</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Plugins/BotSharp.Plugin.ChatHub/SignalRHub.cs

<ul><li>Replace direct <code>_context.HttpContext</code> access with <br><code>Context.GetHttpContext()</code> method call<br> <li> Use null-coalescing operator (<code>?.</code>) for safe property access on <br>potentially null HttpContext<br> <li> Extract <code>conversationId</code> using safe query parameter retrieval with <br><code>FirstOrDefault()</code><br> <li> Prevent NullReferenceException when HttpContext is unavailable in <br>SignalR connections</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1224/files#diff-8128029c568101e1a8e42952f034d04522963436bdd5df61b54c92beba0e6d98">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

