### PR TITLE
optimize DistributedLocker

### DIFF
--- a/src/Infrastructure/BotSharp.Abstraction/Infrastructures/IDistributedLocker.cs
+++ b/src/Infrastructure/BotSharp.Abstraction/Infrastructures/IDistributedLocker.cs
@@ -2,6 +2,6 @@ namespace BotSharp.Abstraction.Infrastructures;
 
 public interface IDistributedLocker
 {
-    bool Lock(string resource, Action action, int timeout = 30);
-    Task<bool> LockAsync(string resource, Func<Task> action, int timeout = 30);
+    bool Lock(string resource, Action action, int timeout = 30, int acquireTimeout = default);
+    Task<bool> LockAsync(string resource, Func<Task> action, int timeout = 30, int acquireTimeout = default);
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add separate `acquireTimeout` parameter for lock acquisition

- Distinguish between lock expiry and acquisition timeout durations

- Pass lock expiry configuration to `RedisDistributedLock` constructor

- Use `acquireTimeout` for `TryAcquire` and `TryAcquireAsync` operations


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Lock Method Calls"] -->|"timeout param"| B["RedisDistributedLock<br/>Expiry Configuration"]
  A -->|"acquireTimeout param"| C["TryAcquire/<br/>TryAcquireAsync"]
  B --> D["Lock Expiry Duration"]
  C --> E["Lock Acquisition Duration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>IDistributedLocker.cs</strong><dd><code>Add acquireTimeout parameter to locker interface</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Infrastructure/BotSharp.Abstraction/Infrastructures/IDistributedLocker.cs

<ul><li>Added <code>acquireTimeout</code> parameter with default value to both <code>Lock</code> and <br><code>LockAsync</code> methods<br> <li> Maintains backward compatibility with default parameter values</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1227/files#diff-a24f40b3b97909f5a929ceb8789d34ad564ad0aa6afe0fefa4121064fc48c1f8">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DistributedLocker.cs</strong><dd><code>Implement separate timeout parameters for lock operations</code></dd></summary>
<hr>

src/Infrastructure/BotSharp.Core/Infrastructures/DistributedLocker.cs

<ul><li>Added <code>acquireTimeoutInSeconds</code> parameter to both <code>Lock</code> and <code>LockAsync</code> <br>methods<br> <li> Convert <code>acquireTimeoutInSeconds</code> to <code>TimeSpan</code> for use in lock <br>acquisition<br> <li> Pass lock expiry timeout to <code>RedisDistributedLock</code> constructor via <br>options lambda<br> <li> Use <code>acquireTimeout</code> for <code>TryAcquire</code> and <code>TryAcquireAsync</code> calls instead of <br>general timeout<br> <li> Update warning messages to reference <code>acquireTimeout</code> instead of <code>timeout</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1227/files#diff-5c837e8c710f3e89782d9cd1caeb9eaeec7f06e0cb288864d1595d1ff53c7845">+10/-8</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

