### PR TITLE
optimize mongodb init

### DIFF
--- a/src/Plugins/BotSharp.Plugin.MongoStorage/MongoDbContext.cs
+++ b/src/Plugins/BotSharp.Plugin.MongoStorage/MongoDbContext.cs
@@ -1,4 +1,5 @@
 using BotSharp.Abstraction.Repositories.Settings;
+using System.Threading;
 
 namespace BotSharp.Plugin.MongoStorage;
 
@@ -7,6 +8,7 @@ public class MongoDbContext
     private readonly MongoClient _mongoClient;
     private readonly string _mongoDbDatabaseName;
     private readonly string _collectionPrefix;
+    private static int _indexesInitialized = 0;
 
     private const string DB_NAME_INDEX = "authSource";
 
@@ -16,6 +18,7 @@ public class MongoDbContext
         _mongoClient = new MongoClient(mongoDbConnectionString);
         _mongoDbDatabaseName = GetDatabaseName(mongoDbConnectionString);
         _collectionPrefix = dbSettings.TablePrefix.IfNullOrEmptyAs("BotSharp")!;
+        CreateIndexes();
     }
 
     private string GetDatabaseName(string mongoDbConnectionString)
@@ -58,6 +61,19 @@ public class MongoDbContext
         return collections.Any();
     }
 
+    private IMongoCollection<TDocument> GetCollection<TDocument>(string name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+        {
+            throw new ArgumentException($"The collection {name} cannot be empty.");
+        }
+
+        var collectionName = $"{_collectionPrefix}_{name}";
+
+        var collection = Database.GetCollection<TDocument>(collectionName);
+        return collection;
+    }
+
     private IMongoCollection<TDocument> GetCollectionOrCreate<TDocument>(string name)
     {
         if (string.IsNullOrWhiteSpace(name))
@@ -76,6 +92,25 @@ public class MongoDbContext
     }
 
     #region Indexes
+
+    public void CreateIndexes()
+    {
+        // Use Interlocked.CompareExchange to ensure the index is initialized only once, ensuring thread safety
+        // 0 indicates uninitialized, 1 indicates initialized
+        if (Interlocked.CompareExchange(ref _indexesInitialized, 1, 0) != 0)
+        {
+            return;
+        }
+
+        // Perform index creation (only executed on the first call).）
+        CreateConversationIndex();
+        CreateConversationStateIndex();
+        CreateContentLogIndex();
+        CreateStateLogIndex();
+        CreateInstructionLogIndex();
+        CreateAgentCodeScriptIndex();
+        CreateAgentTaskIndex();
+    }
     private IMongoCollection<AgentCodeScriptDocument> CreateAgentCodeScriptIndex()
     {
         var collection = GetCollectionOrCreate<AgentCodeScriptDocument>("AgentCodeScripts");
@@ -179,62 +214,62 @@ public class MongoDbContext
     #endregion
 
     public IMongoCollection<AgentDocument> Agents
-        => GetCollectionOrCreate<AgentDocument>("Agents");
+        => GetCollection<AgentDocument>("Agents");
 
     public IMongoCollection<AgentTaskDocument> AgentTasks
-        => CreateAgentTaskIndex();
+        => GetCollection<AgentTaskDocument>("AgentTasks");
 
     public IMongoCollection<AgentCodeScriptDocument> AgentCodeScripts
-        => CreateAgentCodeScriptIndex();
+        => GetCollection<AgentCodeScriptDocument>("AgentCodeScripts");
 
     public IMongoCollection<ConversationDocument> Conversations
-        => CreateConversationIndex();
+        => GetCollection<ConversationDocument>("Conversations");
 
     public IMongoCollection<ConversationDialogDocument> ConversationDialogs
-        => GetCollectionOrCreate<ConversationDialogDocument>("ConversationDialogs");
+        => GetCollection<ConversationDialogDocument>("ConversationDialogs");
 
     public IMongoCollection<ConversationStateDocument> ConversationStates
-        => CreateConversationStateIndex();
+        => GetCollection<ConversationStateDocument>("ConversationStates");
 
     public IMongoCollection<LlmCompletionLogDocument> LlmCompletionLogs
-        => GetCollectionOrCreate<LlmCompletionLogDocument>("LlmCompletionLogs");
+        => GetCollection<LlmCompletionLogDocument>("LlmCompletionLogs");
 
     public IMongoCollection<ConversationContentLogDocument> ContentLogs
-        => CreateContentLogIndex();
+        => GetCollection<ConversationContentLogDocument>("ConversationContentLogs");
 
     public IMongoCollection<ConversationStateLogDocument> StateLogs
-        => CreateStateLogIndex();
+        => GetCollection<ConversationStateLogDocument>("ConversationStateLogs");
 
     public IMongoCollection<UserDocument> Users
-        => GetCollectionOrCreate<UserDocument>("Users");
+        => GetCollection<UserDocument>("Users");
 
     public IMongoCollection<UserAgentDocument> UserAgents
-        => GetCollectionOrCreate<UserAgentDocument>("UserAgents");
+        => GetCollection<UserAgentDocument>("UserAgents");
 
     public IMongoCollection<PluginDocument> Plugins
-        => GetCollectionOrCreate<PluginDocument>("Plugins");
+        => GetCollection<PluginDocument>("Plugins");
 
     public IMongoCollection<TranslationMemoryDocument> TranslationMemories
-        => GetCollectionOrCreate<TranslationMemoryDocument>("TranslationMemories");
+        => GetCollection<TranslationMemoryDocument>("TranslationMemories");
 
     public IMongoCollection<KnowledgeCollectionConfigDocument> KnowledgeCollectionConfigs
-        => GetCollectionOrCreate<KnowledgeCollectionConfigDocument>("KnowledgeCollectionConfigs");
+        => GetCollection<KnowledgeCollectionConfigDocument>("KnowledgeCollectionConfigs");
 
     public IMongoCollection<KnowledgeCollectionFileMetaDocument> KnowledgeCollectionFileMeta
-        => GetCollectionOrCreate<KnowledgeCollectionFileMetaDocument>("KnowledgeCollectionFileMeta");
+        => GetCollection<KnowledgeCollectionFileMetaDocument>("KnowledgeCollectionFileMeta");
 
     public IMongoCollection<RoleDocument> Roles
-        => GetCollectionOrCreate<RoleDocument>("Roles");
+        => GetCollection<RoleDocument>("Roles");
 
     public IMongoCollection<RoleAgentDocument> RoleAgents
-        => GetCollectionOrCreate<RoleAgentDocument>("RoleAgents");
+        => GetCollection<RoleAgentDocument>("RoleAgents");
 
     public IMongoCollection<CrontabItemDocument> CrontabItems
-        => GetCollectionOrCreate<CrontabItemDocument>("CronTabItems");
+        => GetCollection<CrontabItemDocument>("CronTabItems");
 
     public IMongoCollection<GlobalStatisticsDocument> GlobalStats
-        => GetCollectionOrCreate<GlobalStatisticsDocument>("GlobalStats");
+        => GetCollection<GlobalStatisticsDocument>("GlobalStats");
 
     public IMongoCollection<InstructionLogDocument> InstructionLogs
-        => CreateInstructionLogIndex();
+        => GetCollection<InstructionLogDocument>("InstructionLogs");
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Optimize MongoDB initialization with thread-safe index creation

- Separate index creation from collection access logic

- Add new `GetCollection` method for simple collection retrieval

- Replace index creation calls with efficient collection access

- Implement `Interlocked.CompareExchange` for thread-safe initialization


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Constructor"] -->|"calls"| B["CreateIndexes"]
  B -->|"uses Interlocked"| C["Thread-safe initialization"]
  C -->|"creates indexes once"| D["Index methods"]
  E["Collection properties"] -->|"now use"| F["GetCollection"]
  F -->|"replaces"| G["GetCollectionOrCreate/Index methods"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MongoDbContext.cs</strong><dd><code>Thread-safe MongoDB index initialization optimization</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Plugins/BotSharp.Plugin.MongoStorage/MongoDbContext.cs

<ul><li>Added <code>System.Threading</code> import for thread-safe operations<br> <li> Introduced static <code>_indexesInitialized</code> field with <br><code>Interlocked.CompareExchange</code> for thread-safe index initialization<br> <li> Added <code>CreateIndexes()</code> public method that ensures indexes are created <br>only once during first initialization<br> <li> Created new <code>GetCollection<TDocument></code> method for simple collection retrieval <br>without creation<br> <li> Refactored all collection properties to use <code>GetCollection</code> instead of <br><code>GetCollectionOrCreate</code> or index creation methods<br> <li> Moved index creation logic to be called once in constructor via <br><code>CreateIndexes()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1231/files#diff-fa6613fc73bb0ce02076a673e903d6c2b184e2377a8a822df9d83b71b88a006a">+55/-20</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

