### PR TITLE
Add endpoint of "/membase/{graphId}/query"

### DIFF
--- a/src/Plugins/BotSharp.Plugin.Membase/Controllers/MembaseController.cs
+++ b/src/Plugins/BotSharp.Plugin.Membase/Controllers/MembaseController.cs
@@ -1,3 +1,6 @@
+using BotSharp.Plugin.Membase.Models;
+using Microsoft.AspNetCore.Http;
+
 namespace BotSharp.Plugin.Membase.Controllers;
 
 [Authorize]
@@ -13,5 +16,44 @@ public class MembaseController : ControllerBase
     {
         _user = user;
         _services = services;
+    }
+
+    /// <summary>
+    /// Execute a Cypher graph query
+    /// </summary>
+    /// <param name="graphId">The graph identifier</param>
+    /// <param name="request">The Cypher query request containing the query and parameters</param>
+    /// <returns>Query result with columns and data</returns>
+    [HttpPost("/membase/{graphId}/query")]
+    [ProducesResponseType(StatusCodes.Status200OK)]
+    [ProducesResponseType(StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(StatusCodes.Status500InternalServerError)]
+    public async Task<IActionResult> ExecuteGraphQuery(
+        string graphId,
+        [FromBody] CypherQueryRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(graphId))
+        {
+            return BadRequest("Graph ID cannot be empty.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request?.Query))
+        {
+            return BadRequest("Query cannot be empty.");
+        }
+
+        try
+        {
+            var cypherGraphService = _services.GetRequiredService<ICypherGraphService>();
+            var result = await cypherGraphService.Execute(graphId, request.Query, request.Parameters);
+
+            return Ok(result);
+        }
+        catch (Exception ex)
+        {
+            return StatusCode(
+                StatusCodes.Status500InternalServerError,
+                new { message = "An error occurred while executing the query.", error = ex.Message });
+        }
     }
 }


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Add new POST endpoint for executing Cypher graph queries

- Implement input validation for graph ID and query parameters

- Include comprehensive error handling with appropriate HTTP status codes

- Add XML documentation for endpoint usage and parameters


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Client["Client Request"] -- "POST /membase/{graphId}/query" --> Controller["MembaseController"]
  Controller -- "validates input" --> Validation["Input Validation"]
  Validation -- "valid" --> Service["ICypherGraphService"]
  Service -- "executes query" --> Result["Query Result"]
  Result -- "200 OK" --> Client
  Validation -- "invalid" --> Error["400 BadRequest"]
  Error --> Client
  Service -- "exception" --> ServerError["500 InternalServerError"]
  ServerError --> Client
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MembaseController.cs</strong><dd><code>Add Cypher query execution endpoint with validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Plugins/BotSharp.Plugin.Membase/Controllers/MembaseController.cs

<ul><li>Add required using statements for Models and HTTP status codes<br> <li> Implement <code>ExecuteGraphQuery</code> POST endpoint at <code>/membase/{graphId}/query</code><br> <li> Add input validation for graph ID and Cypher query parameters<br> <li> Implement exception handling with appropriate HTTP status code <br>responses<br> <li> Include XML documentation describing endpoint functionality and <br>parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1239/files#diff-131e18b00c2092783d19fd02193580a01cbb2b403413c8bee58eaf7ea61f8490">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

