### PR TITLE
optimize sql driver connections.

### DIFF
--- a/src/Infrastructure/BotSharp.Abstraction/MLTasks/IText2SqlHook.cs
+++ b/src/Infrastructure/BotSharp.Abstraction/MLTasks/IText2SqlHook.cs
@@ -6,7 +6,7 @@ public interface IText2SqlHook : IHookBase
 {
     // Get database type
     string GetDatabaseType(RoleDialogModel message);
-    string GetConnectionString(RoleDialogModel message);
+    string? GetConnectionString(RoleDialogModel message);
     Task SqlGenerated(RoleDialogModel message);
     Task SqlExecuting(RoleDialogModel message);
     Task SqlExecuted(RoleDialogModel message);

--- a/src/Plugins/BotSharp.Plugin.SqlDriver/Controllers/ViewModels/SqlQueryRequest.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/Controllers/ViewModels/SqlQueryRequest.cs
@@ -4,6 +4,10 @@ public class SqlQueryRequest
 {
     public string AgentId { get; set; } = null!;
     public string DbType { get; set; } = null!;
+    /// <summary>
+    /// Data source name
+    /// </summary>
+    public string DataSource { get; set; } = null!;
     public string SqlStatement { get; set; } = null!;
     public string ResultFormat { get; set; } = "markdown";
     public bool IsEphemeral { get; set; } = false;

--- a/src/Plugins/BotSharp.Plugin.SqlDriver/Functions/GetTableDefinitionFn.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/Functions/GetTableDefinitionFn.cs
@@ -1,4 +1,5 @@
 using Microsoft.Data.SqlClient;
+using MongoDB.Driver.Core.Configuration;
 using MySqlConnector;
 using Npgsql;
 
@@ -44,7 +45,9 @@ public class GetTableDefinitionFn : IFunctionCallback
     {
         var settings = _services.GetRequiredService<SqlDriverSetting>();
         var tableDdls = new List<string>();
-        using var connection = new MySqlConnection(settings.MySqlMetaConnectionString ?? settings.MySqlConnectionString);
+
+        var connectionString = settings.Connections.FirstOrDefault(x => x.DbType == "mysql")?.ConnectionString;
+        using var connection = new MySqlConnection(connectionString);
         connection.Open();
 
         foreach (var table in tables)
@@ -79,7 +82,8 @@ public class GetTableDefinitionFn : IFunctionCallback
     {
         var settings = _services.GetRequiredService<SqlDriverSetting>();
         var tableDdls = new List<string>();
-        using var connection = new SqlConnection(settings.SqlServerExecutionConnectionString ?? settings.SqlServerConnectionString);
+        var connectionString = settings.Connections.FirstOrDefault(x => x.DbType == "mssql")?.ConnectionString;
+        using var connection = new SqlConnection(connectionString);
         connection.Open();
 
         foreach (var table in tables)
@@ -132,7 +136,8 @@ public class GetTableDefinitionFn : IFunctionCallback
         var settings = _services.GetRequiredService<SqlDriverSetting>();
         var tableDdls = new List<string>();
         var schemas = "'onebi_hour','onebi_day'";
-        using var connection = new NpgsqlConnection(settings.RedshiftConnectionString);
+        var connectionString = settings.Connections.FirstOrDefault(x => x.DbType == "redshift")?.ConnectionString;
+        using var connection = new NpgsqlConnection(connectionString);
         connection.Open();
 
         foreach (var table in tables)

--- a/src/Plugins/BotSharp.Plugin.SqlDriver/Functions/VerifyDictionaryTerm.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/Functions/VerifyDictionaryTerm.cs
@@ -48,8 +48,9 @@ public class VerifyDictionaryTerm : IFunctionCallback
         IEnumerable<dynamic>? result = null;
         if (!string.IsNullOrWhiteSpace(args.SqlStatement))
         {
-            var settings = _services.GetRequiredService<SqlDriverSetting>();
-            using var connection = new MySqlConnection(settings.MySqlExecutionConnectionString);
+            var sqlHook = _services.GetRequiredService<IText2SqlHook>();
+            var connectionString = sqlHook.GetConnectionString(message);
+            using var connection = new MySqlConnection(connectionString);
             result = connection.Query(args.SqlStatement);
         }
 

--- a/src/Plugins/BotSharp.Plugin.SqlDriver/Hooks/SqlDriverPlanningHook.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/Hooks/SqlDriverPlanningHook.cs
@@ -58,10 +58,10 @@ public class SqlDriverPlanningHook : IPlanningHook
     public async Task<string> GetSummaryAdditionalRequirements(string planner, RoleDialogModel message)
     {
         var settings = _services.GetRequiredService<SqlDriverSetting>();
-        var sqlHooks = _services.GetServices<IText2SqlHook>();
+        var sqlHook = _services.GetRequiredService<IText2SqlHook>();
         var agentService = _services.GetRequiredService<IAgentService>();
 
-        var dbType = !sqlHooks.IsNullOrEmpty() ? sqlHooks.First().GetDatabaseType(message) : settings.DatabaseType;
+        var dbType = sqlHook.GetDatabaseType(message);
         var agent = await agentService.LoadAgent(BuiltInAgentId.SqlDriver);
 
         return agent.Templates.FirstOrDefault(x => x.Name == $"database.summarize.{dbType}")?.Content ?? string.Empty;

--- a/src/Plugins/BotSharp.Plugin.SqlDriver/Models/ExecuteQueryArgs.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/Models/ExecuteQueryArgs.cs
@@ -12,6 +12,10 @@ public class ExecuteQueryArgs
 
     public string DbType { get; set; } = null!;
 
+    public string DataSource { get;set; } = null!;
+
+    public string? ConnectionString { get; set; }
+
     /// <summary>
     /// Beautifying query result
     /// </summary>

--- a/src/Plugins/BotSharp.Plugin.SqlDriver/Services/DbKnowledgeService.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/Services/DbKnowledgeService.cs
@@ -32,7 +32,8 @@ public class DbKnowledgeService
         var collectionName = request.KnowledgebaseCollection;
 
         var tables = new HashSet<string>();
-        using var connection = new MySqlConnection(sqlDriverSettings.MySqlConnectionString);
+
+        using var connection = new MySqlConnection(string.Empty);
 
         var sql = $"select table_name from information_schema.tables where table_schema = @tableSchema";
         var results = connection.Query(sql, new
@@ -98,7 +99,7 @@ public class DbKnowledgeService
         var escapedTableName = MySqlHelper.EscapeString(table);
         var sql = $"SHOW CREATE TABLE `{escapedTableName}`";
 
-        using var connection = new MySqlConnection(settings.MySqlConnectionString);
+        using var connection = new MySqlConnection(string.Empty);
         connection.Open();
         using var command = new MySqlCommand(sql, connection);
         using var reader = command.ExecuteReader();

--- a/src/Plugins/BotSharp.Plugin.SqlDriver/Settings/DataSourceSetting.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/Settings/DataSourceSetting.cs
@@ -1,0 +1,9 @@
+namespace BotSharp.Plugin.SqlDriver.Settings;
+
+
+public class DataSourceSetting
+{
+    public string Name { get; set; } = "default";
+    public string DbType { get; set; } = "mysql";
+    public string ConnectionString { get; set; } = "localhost";
+}

--- a/src/Plugins/BotSharp.Plugin.SqlDriver/Settings/SqlDriverSetting.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/Settings/SqlDriverSetting.cs
@@ -2,14 +2,7 @@ namespace BotSharp.Plugin.SqlDriver.Settings;
 
 public class SqlDriverSetting
 {
-    public string DatabaseType { get; set; } = "mysql";
-    public string MySqlConnectionString { get; set; } = null!;
-    public string MySqlExecutionConnectionString { get; set; } = null!;
-    public string MySqlMetaConnectionString { get; set; } = null!;
-    public string SqlServerConnectionString { get; set; } = null!;
-    public string SqlServerExecutionConnectionString { get; set; } = null!;
-    public string RedshiftConnectionString { get; set; } = null!;
-    public string MongoDbConnectionString { get; set; } = null!;
+    public DataSourceSetting[] Connections { get; set; } = [];
     public bool ExecuteSqlSelectAutonomous { get; set; } = false;
     public bool FormattingResult { get; set; } = true;
 }

--- a/src/Plugins/BotSharp.Plugin.SqlDriver/UtilFunctions/GetTableDefinitionFn.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/UtilFunctions/GetTableDefinitionFn.cs
@@ -44,7 +44,7 @@ public class GetTableDefinitionFn : IFunctionCallback
     {
         var settings = _services.GetRequiredService<SqlDriverSetting>();
         var tableDdls = new List<string>();
-        using var connection = new MySqlConnection(settings.MySqlMetaConnectionString ?? settings.MySqlConnectionString);
+        using var connection = new MySqlConnection(string.Empty);
         connection.Open();
 
         foreach (var table in tables)
@@ -79,7 +79,7 @@ public class GetTableDefinitionFn : IFunctionCallback
     {
         var settings = _services.GetRequiredService<SqlDriverSetting>();
         var tableDdls = new List<string>();
-        using var connection = new SqlConnection(settings.SqlServerExecutionConnectionString ?? settings.SqlServerConnectionString);
+        using var connection = new SqlConnection(string.Empty);
         connection.Open();
 
         foreach (var table in tables)
@@ -132,7 +132,7 @@ public class GetTableDefinitionFn : IFunctionCallback
         var settings = _services.GetRequiredService<SqlDriverSetting>();
         var tableDdls = new List<string>();
         var schemas = "'onebi_hour','onebi_day'";
-        using var connection = new NpgsqlConnection(settings.RedshiftConnectionString);
+        using var connection = new NpgsqlConnection(string.Empty);
         connection.Open();
 
         foreach (var table in tables)

--- a/src/Plugins/BotSharp.Plugin.SqlDriver/UtilFunctions/SqlSelect.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/UtilFunctions/SqlSelect.cs
@@ -1,7 +1,9 @@
 using Microsoft.Data.SqlClient;
 using Microsoft.Data.Sqlite;
+using MongoDB.Driver;
 using MySqlConnector;
 using Npgsql;
+using System.Runtime;
 using static Dapper.SqlMapper;
 
 namespace BotSharp.Plugin.SqlDriver.UtilFunctions;
@@ -9,11 +11,13 @@ namespace BotSharp.Plugin.SqlDriver.UtilFunctions;
 public class SqlSelect : IFunctionCallback
 {
     private readonly IServiceProvider _services;
+    private readonly SqlDriverSetting _settings;
     public string Name => "util-db-sql_select";
     public string Indication => "Generated query statement. I'm pulling the data from database, please wait";
 
-    public SqlSelect(IServiceProvider services)
+    public SqlSelect(IServiceProvider services, SqlDriverSetting setting)
     {
+        _settings = setting;
         _services = services;
     }
 
@@ -28,15 +32,18 @@ public class SqlSelect : IFunctionCallback
         }
 
         var dbHook = _services.GetRequiredService<IText2SqlHook>();
-        var dbConnectionString = dbHook.GetConnectionString(message);
-        var dbType = args.DBProvider.ToLowerInvariant();
+        var dbType = dbHook.GetDatabaseType(message);
+        var dbConnectionString = dbHook.GetConnectionString(message) ??
+            _settings.Connections.FirstOrDefault(c => c.DbType == dbType)?.ConnectionString ??
+            throw new Exception("database connectdion is not found");
+        
 
         var result = dbType switch
         {
-            "mysql" => RunQueryInMySql(args),
-            "sqlserver" or "mssql" => RunQueryInSqlServer(args),
-            "redshift" => RunQueryInRedshift(args),
-            "sqlite" => RunQueryInSqlite(dbHook.GetConnectionString(message), [args.Statement]),
+            "mysql" => RunQueryInMySql(dbConnectionString, args),
+            "sqlserver" or "mssql" => RunQueryInSqlServer(dbConnectionString, args),
+            "redshift" => RunQueryInRedshift(dbConnectionString, args),
+            "sqlite" => RunQueryInSqlite(dbConnectionString, [args.Statement]),
             _ => throw new NotImplementedException($"Database type {dbType} is not supported.")
         };
 
@@ -53,10 +60,9 @@ public class SqlSelect : IFunctionCallback
         return true;
     }
 
-    private IEnumerable<dynamic> RunQueryInMySql(SqlStatement args)
+    private IEnumerable<dynamic> RunQueryInMySql(string connectionString, SqlStatement args)
     {
-        var settings = _services.GetRequiredService<SqlDriverSetting>();
-        using var connection = new MySqlConnection(settings.MySqlExecutionConnectionString);
+        using var connection = new MySqlConnection(connectionString);
         var dictionary = new Dictionary<string, object>();
         foreach (var p in args.Parameters)
         {
@@ -65,10 +71,9 @@ public class SqlSelect : IFunctionCallback
         return connection.Query(args.Statement, dictionary);
     }
 
-    private IEnumerable<dynamic> RunQueryInSqlServer(SqlStatement args)
+    private IEnumerable<dynamic> RunQueryInSqlServer(string connectionString, SqlStatement args)
     {
-        var settings = _services.GetRequiredService<SqlDriverSetting>();
-        using var connection = new SqlConnection(settings.SqlServerExecutionConnectionString ?? settings.SqlServerConnectionString);
+        using var connection = new SqlConnection(connectionString);
         var dictionary = new Dictionary<string, object>();
         foreach (var p in args.Parameters)
         {
@@ -79,15 +84,13 @@ public class SqlSelect : IFunctionCallback
 
     private IEnumerable<dynamic> RunQueryInSqlite(string connectionString, string[] sqlTexts)
     {
-        var settings = _services.GetRequiredService<SqlDriverSetting>();
         using var connection = new SqliteConnection(connectionString);
         return connection.Query(sqlTexts[0]);
     }
 
-    private IEnumerable<dynamic> RunQueryInRedshift(SqlStatement args)
+    private IEnumerable<dynamic> RunQueryInRedshift(string connectionString, SqlStatement args)
     {
-        var settings = _services.GetRequiredService<SqlDriverSetting>();
-        using var connection = new NpgsqlConnection(settings.RedshiftConnectionString);
+        using var connection = new NpgsqlConnection(connectionString);
         var dictionary = new Dictionary<string, object>();
         foreach (var p in args.Parameters)
         {

--- a/src/Plugins/BotSharp.Plugin.SqlDriver/UtilFunctions/VerifyDictionaryTerm.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/UtilFunctions/VerifyDictionaryTerm.cs
@@ -45,8 +45,9 @@ public class VerifyDictionaryTerm : IFunctionCallback
         IEnumerable<dynamic>? result = null;
         if (!string.IsNullOrWhiteSpace(args.SqlStatement))
         {
-            var settings = _services.GetRequiredService<SqlDriverSetting>();
-            using var connection = new MySqlConnection(settings.MySqlExecutionConnectionString);
+            var sqlHook = _services.GetRequiredService<IText2SqlHook>();
+            var connectionString = sqlHook.GetConnectionString(message);
+            using var connection = new MySqlConnection(connectionString);
             result = connection.Query(args.SqlStatement);
         }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Refactor SQL driver connection management to use centralized data source configuration

- Replace multiple database-specific connection string properties with unified `Connections` array

- Add data source name parameter to SQL query execution requests and function arguments

- Implement new endpoint to retrieve connection settings with masked connection strings

- Update all database query methods to accept connection string as parameter instead of retrieving from settings


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SqlDriverSetting<br/>Connections Array"] -- "lookup by name" --> B["DataSourceSetting<br/>DbType, Name, ConnectionString"]
  C["SqlQueryRequest<br/>+ DataSource"] -- "passes to" --> D["ExecuteQueryFn"]
  D -- "retrieves connection" --> A
  E["GetConnectionSettings<br/>Endpoint"] -- "returns masked" --> B
  D -- "passes to" --> F["Database Query Methods<br/>RunQueryInMySql, etc."]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td><strong>IText2SqlHook.cs</strong><dd><code>Make GetConnectionString return type nullable</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1250/files#diff-0c16716eb75775e2ad8d1e95a3c052071e3ea103fb10bebddac80692f7e004fc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SqlDriverController.cs</strong><dd><code>Add data source parameter and new connection settings endpoint</code></dd></td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1250/files#diff-77cdd4698d4d884369c78ac53ece5c0134ed0166ad31af79ba70f0e669bd9e68">+22/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SqlQueryRequest.cs</strong><dd><code>Add DataSource property to SQL query request model</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1250/files#diff-63cd05ed8ddc3aaf22a693a902af3664c223b4e2b561ed2973966255c27c3453">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ExecuteQueryFn.cs</strong><dd><code>Refactor to use connection string parameter and data source lookup</code></dd></td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1250/files#diff-e3d9c7e9211804ff104ea714a3ae1bd2c0646d734bcc88111544dc1862f8c84c">+10/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>GetTableDefinitionFn.cs</strong><dd><code>Update database methods to accept connection string parameter</code></dd></td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1250/files#diff-ecb2be20019c04e44eea77281502e75946b32157599d2c1c96de3d6bdda725ea">+8/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SqlSelect.cs</strong><dd><code>Refactor query methods to use passed connection string parameter</code></dd></td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1250/files#diff-d0c13a48e145b79ad258020ddad2c644993069fde17cc8f428e06c78b6243f22">+18/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>VerifyDictionaryTerm.cs</strong><dd><code>Use SQL hook to retrieve connection string instead of settings</code></dd></td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1250/files#diff-23aa676143369893616ca870d2fcd07d23db88e9dfdc52a5d72b4ebabb6875c6">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SqlDriverPlanningHook.cs</strong><dd><code>Simplify to use single required SQL hook instance</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1250/files#diff-df1711a71f3921861f46e2f0e5838aa1eb13339ee2432f0b99c6cb9bffc94feb">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ExecuteQueryArgs.cs</strong><dd><code>Add DataSource and ConnectionString properties to execute query </code><br><code>arguments</code></dd></td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1250/files#diff-66c55750414f50c0c7283a9111ce53e4c92c68bb9fa9c839ef30f4607972520f">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DbKnowledgeService.cs</strong><dd><code>Update connection initialization to use empty string placeholder</code></dd></td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1250/files#diff-84fb7b01eb6416b3f28f57722056c360a1c9f6c19c8e4e66ddd85123b03fa4f7">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DataSourceSetting.cs</strong><dd><code>Create new data source configuration model class</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1250/files#diff-bea6d017d92d9bd095447921303377c8fe9c55fdb82693523f1b83b8c51ac165">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SqlDriverSetting.cs</strong><dd><code>Replace individual connection strings with unified Connections array</code></dd></td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1250/files#diff-278906356338e28213fcdb2c1cd908a250c015619c0fe6bec0ab035ec2ec3841">+1/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>GetTableDefinitionFn.cs</strong><dd><code>Update connection initialization to use empty string placeholder</code></dd></td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1250/files#diff-17ac0d37f7de2d8ee256941e038fe6504519c78251da5c296ac2b6a1524f9ddf">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SqlSelect.cs</strong><dd><code>Refactor query methods to use passed connection string parameter</code></dd></td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1250/files#diff-bc55b4c44c80c5071384317958222aa08bf20064e2fa3bbb4aebb8c4aa0d9898">+20/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>VerifyDictionaryTerm.cs</strong><dd><code>Use SQL hook to retrieve connection string instead of settings</code></dd></td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1250/files#diff-53090f0a393a3bbd0acc607e77441266b4ee9f8667abac69939afd94a7de585d">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

