### PR TITLE
fix openapi compatibility

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -139,7 +139,7 @@
     <PackageVersion Include="EntityFrameworkCore.BootKit" Version="10.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
-    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.1.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="8.1.4" />
     <PackageVersion Include="AspNet.Security.OAuth.GitHub" Version="8.3.0" />
     <PackageVersion Include="AspNet.Security.OAuth.Keycloak" Version="8.3.0" />
     <PackageVersion Include="AspNet.Security.OAuth.Weixin" Version="8.3.0" />

--- a/src/Infrastructure/BotSharp.OpenAPI/BotSharpOpenApiExtensions.cs
+++ b/src/Infrastructure/BotSharp.OpenAPI/BotSharpOpenApiExtensions.cs
@@ -13,6 +13,9 @@ using BotSharp.OpenAPI.BackgroundServices;
 using System.Text.Json.Serialization;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.OpenApi;
+#if NET8_0
+using Microsoft.OpenApi.Models;
+#endif
 
 namespace BotSharp.OpenAPI;
 
@@ -168,6 +171,21 @@ public static class BotSharpOpenApiExtensions
                     Name = "Authorization",
                     Type = SecuritySchemeType.ApiKey
                 });
+#if NET8_0
+                c.AddSecurityRequirement(new OpenApiSecurityRequirement {
+                   {
+                     new OpenApiSecurityScheme
+                     {
+                       Reference = new OpenApiReference
+                       {
+                         Type = ReferenceType.SecurityScheme,
+                         Id = "Bearer"
+                       }
+                      },
+                      Array.Empty<string>()
+                   }
+                });
+#elif NET10_0
                 c.AddSecurityRequirement(x => new OpenApiSecurityRequirement
                 {
                    {
@@ -175,8 +193,10 @@ public static class BotSharpOpenApiExtensions
                      []
                    }
                 });
+#endif
             }
         );
+
 
         services.AddHttpContextAccessor();
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Downgrade Swashbuckle.AspNetCore to 8.1.4 for NET8_0 compatibility

- Add conditional compilation for OpenAPI security requirement definitions

- Support both NET8_0 and NET10_0 framework targets with different API patterns


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["NET8_0 & NET10_0<br/>Framework Support"] --> B["Conditional<br/>Compilation"]
  B --> C["OpenAPI Security<br/>Requirement Setup"]
  D["Swashbuckle.AspNetCore<br/>Version Downgrade"] --> E["Compatibility<br/>Fix"]
  C --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BotSharpOpenApiExtensions.cs</strong><dd><code>Add framework-specific OpenAPI security configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Infrastructure/BotSharp.OpenAPI/BotSharpOpenApiExtensions.cs

<ul><li>Added conditional compilation directives for NET8_0 and NET10_0 <br>frameworks<br> <li> Implemented NET8_0-specific OpenAPI security requirement using <br>OpenApiSecurityRequirement object<br> <li> Implemented NET10_0-specific OpenAPI security requirement using <br>OpenApiSecuritySchemeReference<br> <li> Added missing using statement for Microsoft.OpenApi.Models under <br>NET8_0 condition</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1259/files#diff-fb640c05236d6257d327f05eaf90052af8446b52121a3198e40f874cc546574b">+20/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Directory.Packages.props</strong><dd><code>Downgrade Swashbuckle.AspNetCore for NET8_0</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Directory.Packages.props

<ul><li>Downgraded Swashbuckle.AspNetCore version from 10.1.0 to 8.1.4 for <br>NET8_0 target framework<br> <li> Ensures compatibility with NET8_0 OpenAPI implementation</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1259/files#diff-5baf5f9e448ad54ab25a091adee0da05d4d228481c9200518fcb1b53a65d4156">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

