### PR TITLE
fix reasoning effort

### DIFF
--- a/src/Plugins/BotSharp.Plugin.OpenAI/Providers/Chat/ChatCompletionProvider.cs
+++ b/src/Plugins/BotSharp.Plugin.OpenAI/Providers/Chat/ChatCompletionProvider.cs
@@ -595,8 +595,12 @@ public class ChatCompletionProvider : IChatCompletion
         float? temperature = null;
         ChatReasoningEffortLevel? reasoningEffortLevel = null;
 
-        var level = _state.GetState("reasoning_effort_level")
-                          .IfNullOrEmptyAs(agent?.LlmConfig?.ReasoningEffortLevel);
+        var level = _state.GetState("reasoning_effort_level");
+
+        if (string.IsNullOrEmpty(level) && _model == agent?.LlmConfig?.Model)
+        {
+            level = agent?.LlmConfig?.ReasoningEffortLevel;
+        }
 
         if (settings == null)
         {


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fix reasoning effort level fallback logic

- Only use agent config when model matches current model

- Prevent incorrect reasoning effort from being applied


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Get reasoning_effort_level from state"] --> B{"Is level empty AND<br/>model matches agent config?"}
  B -->|Yes| C["Use agent config<br/>ReasoningEffortLevel"]
  B -->|No| D["Use state value<br/>or null"]
  C --> E["Parse reasoning effort level"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ChatCompletionProvider.cs</strong><dd><code>Add model matching check for reasoning effort fallback</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Plugins/BotSharp.Plugin.OpenAI/Providers/Chat/ChatCompletionProvider.cs

<ul><li>Changed reasoning effort level fallback logic from unconditional to <br>conditional<br> <li> Added model matching check before using agent config value<br> <li> Only applies agent config reasoning effort when current model matches <br>agent's configured model</ul>


</details>


  </td>
  <td><a href="https://github.com/SciSharp/BotSharp/pull/1276/files#diff-593bf7f9bf86514c44c1d5767f86317d48683d8755d1b8554573b4db3391c987">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

