### PR TITLE
feat: Invoked IText2SqlHook.SqlExecuting in SqlSelectFn and ExecuteQueryFn

### DIFF
--- a/src/Plugins/BotSharp.Plugin.SqlDriver/Functions/ExecuteQueryFn.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/Functions/ExecuteQueryFn.cs
@@ -22,9 +22,13 @@ public class ExecuteQueryFn : IFunctionCallback
 
     public async Task<bool> Execute(RoleDialogModel message)
     {
+        var dbHook = _services.GetRequiredService<IText2SqlHook>();
+        // The hook may rewrite message.FunctionArgs (e.g. tag the statements for
+        // traceability), so it must run before the args are deserialized.
+        await dbHook.SqlExecuting(message);
+
         var args = JsonSerializer.Deserialize<ExecuteQueryArgs>(message.FunctionArgs) ?? new();
         //var refinedArgs = await RefineSqlStatement(message, args);
-        var dbHook = _services.GetRequiredService<IText2SqlHook>();
         var dbType = dbHook.GetDatabaseType(message);
         var connectionString = _setting.Connections.FirstOrDefault(x => x.Name.Equals(args.DataSource, StringComparison.OrdinalIgnoreCase))?.ConnectionString;
         var dbConnectionString = dbHook.GetConnectionString(message, args.DataSource) ?? connectionString ?? throw new Exception("database connection is not found");

--- a/src/Plugins/BotSharp.Plugin.SqlDriver/Functions/SqlSelectFn.cs
+++ b/src/Plugins/BotSharp.Plugin.SqlDriver/Functions/SqlSelectFn.cs
@@ -15,6 +15,11 @@ public class SqlSelectFn : IFunctionCallback
 
     public async Task<bool> Execute(RoleDialogModel message)
     {
+        var dbHook = _services.GetRequiredService<IText2SqlHook>();
+        // The hook may rewrite message.FunctionArgs (e.g. tag the statement for
+        // traceability), so it must run before the args are deserialized.
+        await dbHook.SqlExecuting(message);
+
         var args = JsonSerializer.Deserialize<SqlStatement>(message.FunctionArgs);
 
         if (args.GeneratedWithoutTableDefinition)
@@ -24,7 +29,6 @@ public class SqlSelectFn : IFunctionCallback
         }
 
         // check if need to instantely
-        var dbHook = _services.GetRequiredService<IText2SqlHook>();
         var dbType = dbHook.GetDatabaseType(message);
         var dbConnectionString = dbHook.GetConnectionString(message) ?? 
             throw new Exception("database connectdion is not found");


### PR DESCRIPTION
feat: Invoked `IText2SqlHook.SqlExecuting` in `SqlSelectFn` and `ExecuteQueryFn` before deserializing the function args, so hooks can rewrite the SQL statements (e.g. inject trace tags) prior to execution.