### PR TITLE
Move inbound translation from RoutingService to ConversationService.S…

### DIFF
--- a/src/Infrastructure/BotSharp.Core/Conversations/Services/ConversationService.SendMessage.cs
+++ b/src/Infrastructure/BotSharp.Core/Conversations/Services/ConversationService.SendMessage.cs
@@ -45,8 +45,7 @@ public partial class ConversationService
 
         // Handle multi-language for input. Runs ahead of the hooks so they evaluate English content,
         // and covers both routing paths from a single place.
-        var isTranslated = await TranslateInboundMessage(agent, message);
-        var inboundContent = message.Content;
+        await TranslateInboundMessage(agent, message);
 
         var hooks = _services.GetHooksOrderByPriority<IConversationHook>(message.CurrentAgentId);
         foreach (var hook in hooks)
@@ -70,15 +69,6 @@ public partial class ConversationService
                 await routing.Context.Pop();
                 break;
             }
-        }
-
-        // A hook may swap in its own reply (rate limit, intent template). The SecondaryContent set above
-        // still holds the user's original text, and consumers render SecondaryContent in preference to
-        // Content, so drop it - otherwise the user is shown their own message instead of the hook's
-        // reply. Gated on isTranslated so we only ever clear a SecondaryContent we set ourselves.
-        if (isTranslated && message.Content != inboundContent)
-        {
-            message.SecondaryContent = null;
         }
 
         if (!stopCompletion)

--- a/src/Infrastructure/BotSharp.Core/Conversations/Services/ConversationService.SendMessage.cs
+++ b/src/Infrastructure/BotSharp.Core/Conversations/Services/ConversationService.SendMessage.cs
@@ -43,6 +43,11 @@ public partial class ConversationService
             message.Payload = replyMessage.Payload;
         }
 
+        // Handle multi-language for input. Runs ahead of the hooks so they evaluate English content,
+        // and covers both routing paths from a single place.
+        var isTranslated = await TranslateInboundMessage(agent, message);
+        var inboundContent = message.Content;
+
         var hooks = _services.GetHooksOrderByPriority<IConversationHook>(message.CurrentAgentId);
         foreach (var hook in hooks)
         {
@@ -65,6 +70,15 @@ public partial class ConversationService
                 await routing.Context.Pop();
                 break;
             }
+        }
+
+        // A hook may swap in its own reply (rate limit, intent template). The SecondaryContent set above
+        // still holds the user's original text, and consumers render SecondaryContent in preference to
+        // Content, so drop it - otherwise the user is shown their own message instead of the hook's
+        // reply. Gated on isTranslated so we only ever clear a SecondaryContent we set ourselves.
+        if (isTranslated && message.Content != inboundContent)
+        {
+            message.SecondaryContent = null;
         }
 
         if (!stopCompletion)

--- a/src/Infrastructure/BotSharp.Core/Conversations/Services/ConversationService.Translation.cs
+++ b/src/Infrastructure/BotSharp.Core/Conversations/Services/ConversationService.Translation.cs
@@ -1,26 +1,29 @@
 using BotSharp.Abstraction.Infrastructures.Enums;
 
-namespace BotSharp.Core.Routing;
+namespace BotSharp.Core.Conversations.Services;
 
-public partial class RoutingService
+public partial class ConversationService
 {
     private const string TranslationPromptName = "translation_prompt";
 
     /// <summary>
-    /// Normalize an inbound user message to English so routing rules, agent instructions and
-    /// function arguments are always evaluated in English. The user's original text is kept in
-    /// SecondaryContent. Shared by InstructLoop and InstructDirect so every entry point into the
-    /// routing service behaves the same way.
+    /// Normalize an inbound user message to English so conversation hooks, routing rules, agent
+    /// instructions and function arguments are always evaluated in English. The user's original
+    /// text is kept in SecondaryContent. Runs once in SendMessage ahead of the hook loop, so both
+    /// routing paths and every hook observe the same normalized message.
     /// </summary>
-    private async Task TranslateInboundMessage(Agent agent, RoleDialogModel message)
+    /// <returns>
+    /// True when the message was translated and SecondaryContent now holds the user's original text.
+    /// Callers rely on this to tell apart a SecondaryContent this method authored from one it never
+    /// touched, so it must stay false on every early return.
+    /// </returns>
+    private async Task<bool> TranslateInboundMessage(Agent agent, RoleDialogModel message)
     {
         var agentSettings = _services.GetRequiredService<AgentSettings>();
         if (!agentSettings.EnableTranslator)
         {
-            return;
+            return false;
         }
-
-        var states = _services.GetRequiredService<IConversationStateService>();
 
         // The caller supplies the language through the request states; the server does not detect it.
         // TranslationService back-fills StateConst.LANGUAGE only when the state is absent, which cannot
@@ -28,15 +31,15 @@ public partial class RoutingService
         // the /translate endpoint instead.
         // Unknown is excluded to stay in sync with TranslationResponseHook: it means the language has
         // not been resolved, so translating would only paraphrase the user's own words.
-        var language = states.GetState(StateConst.LANGUAGE, LanguageType.ENGLISH);
+        var language = _state.GetState(StateConst.LANGUAGE, LanguageType.ENGLISH);
         if (language == LanguageType.ENGLISH || language == LanguageType.UNKNOWN)
         {
-            return;
+            return false;
         }
 
         // TranslationService reads the prompt template off the agent it is handed, and only the
         // AI Assistant defines it. Fall back to that agent when the executing one has no template,
-        // which is the normal case for the task agents reaching us through InstructDirect.
+        // which is the normal case for the task agents handled by InstructDirect.
         var host = agent;
         if (host?.Templates?.Any(x => x.Name == TranslationPromptName) != true)
         {
@@ -49,5 +52,7 @@ public partial class RoutingService
         message.Content = await translator.Translate(host, message.MessageId, message.Content,
             language: LanguageType.ENGLISH,
             clone: false);
+
+        return true;
     }
 }

--- a/src/Infrastructure/BotSharp.Core/Routing/RoutingService.InstructLoop.cs
+++ b/src/Infrastructure/BotSharp.Core/Routing/RoutingService.InstructLoop.cs
@@ -23,9 +23,6 @@ public partial class RoutingService
 
         await _context.Push(_router.Id);
 
-        // Handle multi-language for input
-        await TranslateInboundMessage(_router, message);
-
         dialogs.Add(message);
         Context.SetDialogs(dialogs);
         await storage.Append(convService.ConversationId, message);

--- a/src/Infrastructure/BotSharp.Core/Routing/RoutingService.cs
+++ b/src/Infrastructure/BotSharp.Core/Routing/RoutingService.cs
@@ -31,10 +31,6 @@ public partial class RoutingService : IRoutingService
         var conv = _services.GetRequiredService<IConversationService>();
         var storage = _services.GetRequiredService<IConversationStorage>();
 
-        // Must run before the message is persisted so the stored record matches InstructLoop:
-        // Content in English, the user's original text in SecondaryContent.
-        await TranslateInboundMessage(agent, message);
-
         await storage.Append(conv.ConversationId, message);
 
         dialogs.Add(message);

--- a/src/Infrastructure/BotSharp.Logger/Hooks/RateLimitConversationHook.cs
+++ b/src/Infrastructure/BotSharp.Logger/Hooks/RateLimitConversationHook.cs
@@ -23,7 +23,9 @@ public class RateLimitConversationHook : ConversationHookBase
     {
         var settings = _services.GetRequiredService<ConversationSetting>();
         var states = _services.GetRequiredService<IConversationStateService>();
-        
+        var storage = _services.GetRequiredService<IConversationStorage>();
+
+        var convId = states.GetConversationId();
         var rateLimit = settings.RateLimit;
         var channel = states.GetState("channel");
 
@@ -31,8 +33,10 @@ public class RateLimitConversationHook : ConversationHookBase
         var charCount = message.Content.Length;
         if (charCount > rateLimit.MaxInputLengthPerRequest)
         {
+            await storage.Append(convId, message);
             message.Content = $"The number of characters in your message exceeds the system maximum of {rateLimit.MaxInputLengthPerRequest}";
             message.StopCompletion = true;
+            ClearMessage(message);
             return;
         }
 
@@ -50,8 +54,10 @@ public class RateLimitConversationHook : ConversationHookBase
             var seconds = (DateTime.UtcNow - userSents.First().CreatedAt).TotalSeconds;
             if (seconds < rateLimit.MinTimeSecondsBetweenMessages)
             {
+                await storage.Append(convId, message);
                 message.Content = "Your message sending frequency exceeds the frequency specified by the system. Please try again later.";
                 message.StopCompletion = true;
+                ClearMessage(message);
                 return;
             }
         }
@@ -69,10 +75,19 @@ public class RateLimitConversationHook : ConversationHookBase
 
             if (results.Count > rateLimit.MaxConversationPerDay)
             {
+                await storage.Append(convId, message);
                 message.Content = $"The number of conversations you have exceeds the system maximum of {rateLimit.MaxConversationPerDay}";
                 message.StopCompletion = true;
+                ClearMessage(message);
                 return;
             }
         }
+    }
+
+    private void ClearMessage(RoleDialogModel message)
+    {
+        message.SecondaryContent = null;
+        message.RichContent = null;
+        message.SecondaryRichContent = null;
     }
 }


### PR DESCRIPTION
…endMessage

TranslateInboundMessage was called from both InstructDirect and InstructLoop, leaving the two routing paths to stay in sync by hand. SendMessage is the only caller of either, so run it once there, ahead of the conversation hook loop.

Running before the hooks means they now evaluate English content, which matters for RoutingConversationHook: it embeds message.Content and classifies intent against an English-trained model.

It also means a hook can overwrite Content after SecondaryContent has been set to the user's original text. Consumers render SecondaryContent in preference to Content, so a rate-limited or intent-templated reply would be replaced by the user's own message on its way back to them. Clear SecondaryContent when a hook rewrites Content, gated on whether translation actually ran so we only ever clear a value we set ourselves. This matches RoleDialogModel.From, which already drops SecondaryContent when it replaces Content.