### PR TITLE
Fix startup crash when published as self-contained single-file executable

### DIFF
--- a/src/Infrastructure/BotSharp.Core/Plugins/PluginLoader.cs
+++ b/src/Infrastructure/BotSharp.Core/Plugins/PluginLoader.cs
@@ -18,7 +18,10 @@ public class PluginLoader(IServiceCollection services,
 
     public void Load(Action<Assembly> loaded, string? plugin = null)
     {
-        _executingDir = Directory.GetParent(Assembly.GetEntryAssembly().Location).FullName;
+        // Assembly.GetEntryAssembly().Location is empty when the app is published
+        // as a self-contained single-file executable, which makes Directory.GetParent()
+        // throw. AppContext.BaseDirectory is populated correctly in that case too.
+        _executingDir = AppContext.BaseDirectory;
 
         settings.Assemblies.ToList().ForEach(assemblyName =>
         {

--- a/tests/BotSharp.Core.UnitTests/Plugins/PluginLoaderTests.cs
+++ b/tests/BotSharp.Core.UnitTests/Plugins/PluginLoaderTests.cs
@@ -1,0 +1,55 @@
+using System.Reflection;
+using BotSharp.Abstraction.Plugins;
+using BotSharp.Core.Plugins;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Xunit;
+
+namespace BotSharp.Core.UnitTests.Plugins;
+
+public class PluginLoaderTests
+{
+    // Regression test for https://github.com/SciSharp/BotSharp/issues/669:
+    // PluginLoader used to derive its plugin search directory from
+    // Assembly.GetEntryAssembly().Location. .NET leaves that empty when the app
+    // is published as a self-contained single-file executable, which made
+    // Directory.GetParent(string.Empty) throw an ArgumentException before the
+    // app could even start. PluginLoader now uses AppContext.BaseDirectory,
+    // which resolves correctly in that scenario too.
+    [Fact]
+    public void Load_does_not_throw_and_resolves_executing_dir_from_app_context_base_directory()
+    {
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder().Build();
+        var settings = new PluginSettings { Assemblies = [] };
+        var loader = new PluginLoader(services, config, settings);
+
+        var exception = Record.Exception(() => loader.Load(_ => { }));
+
+        Assert.Null(exception);
+
+        var executingDir = typeof(PluginLoader)
+            .GetField("_executingDir", BindingFlags.NonPublic | BindingFlags.Static)!
+            .GetValue(null) as string;
+
+        Assert.Equal(AppContext.BaseDirectory, executingDir);
+    }
+
+    [Fact]
+    public void Load_finds_and_loads_plugin_assembly_from_executing_dir()
+    {
+        // BotSharp.Core.Rules is a real ProjectReference of this test project, so its
+        // .dll is copied next to the test host's own assembly (AppContext.BaseDirectory) -
+        // the exact directory PluginLoader now searches for plugin assemblies.
+        var services = new ServiceCollection();
+        var config = new ConfigurationBuilder().Build();
+        var settings = new PluginSettings { Assemblies = ["BotSharp.Core.Rules"] };
+        var loader = new PluginLoader(services, config, settings);
+
+        Assembly? loadedAssembly = null;
+        loader.Load(assembly => loadedAssembly = assembly);
+
+        Assert.NotNull(loadedAssembly);
+        Assert.Equal("BotSharp.Core.Rules", loadedAssembly!.GetName().Name);
+    }
+}


### PR DESCRIPTION
## Problem

`PluginLoader.Load()` derived its plugin search directory from `Assembly.GetEntryAssembly().Location`:

```csharp
_executingDir = Directory.GetParent(Assembly.GetEntryAssembly().Location).FullName;
```

.NET leaves `Location` empty (`""`) when the app is published as a **self-contained, single-file executable** (`-p:PublishSingleFile=true --self-contained true`). `Directory.GetParent("")` then throws, crashing the app before it can even start:

```
Unhandled exception. System.ArgumentException: The value cannot be an empty string. (Parameter 'path')
   at System.ArgumentException.ThrowNullOrEmptyException(String argument, String paramName)
   at System.IO.Directory.GetParent(String path)
   at BotSharp.Core.Plugins.PluginLoader.Load(Action`1 loaded, String plugin)
   at BotSharp.Core.BotSharpCoreExtensions.RegisterPlugins(IServiceCollection services, IConfiguration config)
   at BotSharp.Core.BotSharpCoreExtensions.AddBotSharpCore(IServiceCollection services, IConfiguration config, Action`1 configOptions)
   at Program.<Main>$(String[] args)
```

Fixes #669

## Fix

Use `AppContext.BaseDirectory` instead, which resolves correctly for both regular and single-file-published deployments.

## Verification

- **Reproduced the original crash** by publishing with `dotnet publish -r linux-x64 --self-contained true -p:PublishSingleFile=true` and running the resulting binary directly — got the exact stack trace from #669.
- **Confirmed the fix resolves it** — same publish/run steps after the change start the app cleanly instead of crashing.
- `dotnet run` (the documented dev workflow) verified unaffected before and after.
- Added two regression tests in `tests/BotSharp.Core.UnitTests/Plugins/PluginLoaderTests.cs`:
  - asserts `Load()` doesn't throw and that the resolved executing directory matches `AppContext.BaseDirectory`
  - asserts it can still find and load a real plugin assembly from that directory
- Full `BotSharp.Core.UnitTests` suite passes: 376/376.
